### PR TITLE
 Shutdown service when last client unbinds and cleanup exceptions that…

### DIFF
--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothBroadcastReceiver.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothBroadcastReceiver.java
@@ -19,8 +19,14 @@ class BluetoothBroadcastReceiver extends BroadcastReceiver {
         m_ConnectionMgr = new WeakReference<BluetoothConnectionMgr>(connectionMgr);
 
         IntentFilter filter = new IntentFilter();
+
         // TOOD: Register for all intents of interest here...
+
         context.registerReceiver(this, filter);
+    }
+
+    public void unregister(Context context) {
+        context.unregisterReceiver(this);
     }
 
     @Override

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
@@ -54,6 +54,7 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
     private String m_Description = "Uninitialized";
     private BluetoothAdapter m_BluetoothAdapter;
     private BluetoothServerSocket m_ServerSocket;
+    private BluetoothBroadcastReceiver m_BluetoothBroadcastReceiver;
 
     private WeakReference<Context> m_HostContext;
 
@@ -67,7 +68,7 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
 
         // Init a broadcast receiver that will invoke APIs on this class to get stuff
         // done in response to Bluetooth events...
-        new BluetoothBroadcastReceiver(hostContext, this);
+        m_BluetoothBroadcastReceiver = new BluetoothBroadcastReceiver(hostContext, this);
 
         // TODO: Reconsider storing the context - don't think we need to keep it around
         m_HostContext = new WeakReference<Context>(hostContext);
@@ -101,6 +102,17 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
             m_Description = String.format("%s <%s>", m_BluetoothAdapter.getName(),
                     m_BluetoothAdapter.getAddress() );
         }
+    }
+
+    @Override
+    public void requestHalt() {
+        android.util.Log.i(TAG, "requestHalt()");
+        super.requestHalt();
+
+        // Stop receiving BT intents...
+        Context context = m_HostContext.get();
+        if (context != null)
+            m_BluetoothBroadcastReceiver.unregister(context);
     }
 
     @Override

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/websocket/WebsocketConnectionMgr.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/websocket/WebsocketConnectionMgr.java
@@ -116,8 +116,9 @@ public class WebsocketConnectionMgr extends WebSocketServer implements IConnecti
             WebSocket ws = m_Websocket.get();
 
             if ( ws != null ) {
-                retVal = ws.getRemoteSocketAddress().toString();
-                retVal = retVal.substring(1);
+                InetSocketAddress addr = ws.getRemoteSocketAddress();
+                if ( addr != null )
+                    retVal = addr.toString().substring(1);
             }
 
             return retVal;


### PR DESCRIPTION
… resulted.  This is probably not the ideal model for a real service.  I'd consider continuing the service as long as we have open connections after the last client unbinds.  This will get into trouble with the current TCP implementation which does a bad job of detecting dead connections.  

Meantime, this is an easy first cut and works fine with a single app model.