### PR TITLE
Add high-water mark tracking

### DIFF
--- a/AndroidServer/baseplugin/msgplugin/Message.java
+++ b/AndroidServer/baseplugin/msgplugin/Message.java
@@ -1,4 +1,4 @@
-package msgtools;
+package msgplugin;
 
 import java.nio.ByteBuffer;
 

--- a/AndroidServer/msgserver/build.gradle
+++ b/AndroidServer/msgserver/build.gradle
@@ -44,6 +44,12 @@ android {
     // This path should reference the location of your customer-specific plugins
     String MsgPluginDir = project.hasProperty('plugindir') ? project.getProperty('plugindir') : '../baseplugin'
 
+    println '\n===================== MSG PATHS ==========================='
+    println 'MsgAppDir=' + file(MsgAppDir).absolutePath
+    println 'GeneratedMsgDir=' + file(GeneratedMsgDir).absolutePath
+    println 'MsgPluginDir=' + file(MsgPluginDir).absolutePath
+    println '===========================================================\n'
+
     sourceSets {
         main { java.srcDirs = ['src/main/java', MsgPluginDir, MsgAppDir, GeneratedMsgDir,'../Java-WebSocket/src/main/java'] }
     }

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/MessageRouterThread.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/MessageRouterThread.java
@@ -84,6 +84,7 @@ public class MessageRouterThread extends Thread implements IConnectionMgrListene
 
     @Override
     public void run() {
+        int queueHighwaterCount = 0;
         try {
             while (m_HaltRequested == false) {
                 Message msg = m_BlockingQueue.poll(POLL_TIMEOUT, TimeUnit.SECONDS);
@@ -114,8 +115,14 @@ public class MessageRouterThread extends Thread implements IConnectionMgrListene
 
                         default:
                             routeMessage(msg);
-                            if ( m_BlockingQueue.size() > 100 ) {
+                            int queueSize = m_BlockingQueue.size();
+                            if ( queueSize > 100 && queueHighwaterCount <= 100 ) {
                                 android.util.Log.w(TAG, "MsgQueue over 100");
+                            }
+
+                            if (queueSize > queueHighwaterCount ) {
+                                android.util.Log.i(TAG, "New queue high water count: " + queueHighwaterCount);
+                                queueHighwaterCount = queueSize;
                             }
                     }
                 }

--- a/MsgApp/java/msgtools/FieldInfo.java
+++ b/MsgApp/java/msgtools/FieldInfo.java
@@ -1,5 +1,7 @@
 package msgtools;
 
+import msgplugin.Message;
+
 public class FieldInfo
 {
     public FieldInfo(String n, String d, String u, int c)
@@ -33,7 +35,7 @@ public class FieldInfo
             return ret;
         }
     }
-    public void set(Message message, String value) throws  java.lang.reflect.InvocationTargetException, NoSuchMethodException, IllegalArgumentException, IllegalAccessException
+    public void set(Message message, String value) throws  java.lang.reflect.InvocationTargetException, NoSuchMethodException, java.lang.IllegalArgumentException, java.lang.IllegalAccessException
     {
         Class<?> c = message.getClass();
         java.lang.reflect.Method method = c.getMethod("Set" + name);

--- a/MsgApp/java/msgtools/Reflection.java
+++ b/MsgApp/java/msgtools/Reflection.java
@@ -2,10 +2,12 @@ package msgtools;
 
 import java.lang.Class;
 import java.lang.reflect.*;
+import java.lang.IllegalAccessException;
 import java.util.Hashtable;
 import java.util.List;
 import java.util.ArrayList;
 import java.nio.ByteBuffer;
+import msgplugin.Message;
 
 import headers.NetworkHeader;
 


### PR DESCRIPTION
Now logging new high-water marks on the routing thread queue to track overflow conditions.  The queue is in theory unlimited, but if we start falling behind at pace it's nice to see that in the log when we're troubleshooting.