### PR TITLE
Add logic to use SSL websockets if the host page is from a secure source

### DIFF
--- a/MsgApp/Messaging.js
+++ b/MsgApp/Messaging.js
@@ -35,7 +35,11 @@ MessagingClient.prototype.connect = function(server, port) {
     this.disconnect()
 
     // don't specify subprotocol, our Qt Websocket server doesn't support that
-    this.webSocket = new WebSocket("ws://"+server+":" + port);
+    var protocol = 'ws://'
+    if (location.protocol === 'https:') 
+        protocol='wss://'
+
+    this.webSocket = new WebSocket(protocol+server+":" + port);
     this.webSocket.binaryType = 'arraybuffer';
     this.webSocket.onopen = this.onopen.bind(this);
     this.webSocket.onclose = this.onclose.bind(this);


### PR DESCRIPTION
If a host page comes from a secure source (https) then the browser requires Websocket connections to do the same.  Some simple logic to detect and manage that.

Note that one you pull from a secure source your Websocket server has to support SSL connections in such a way to make the browser trust your server.   If your Websocket destination is coming from the same place as your web page no problem.  If you intend to go to localhost or elsewhere you will need to sort out certs.

This commit does not make MsgServer or Android support secure Websockets.