### PR TITLE
Attempt to connect and reconnect to BT devices

### DIFF
--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
@@ -46,6 +46,7 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
     private static final String TAG = BluetoothConnectionMgr.class.getSimpleName();
     private static final String SERVER_NAME = "AndroidServer";
     private static final int ACCEPT_TIMEOUT = 1000;
+    private static final int CONNECTION_ATTEMPTS = -1;  // Each attempt is about 12 seconds, -1 to go forever
 
     // Setup a constant with the well known SPP UUID
     private static final UUID SPP_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
@@ -131,7 +132,7 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
             Set<BluetoothDevice> devs = m_BluetoothAdapter.getBondedDevices();
             for (BluetoothDevice dev : devs) {
                 BluetoothConnectionThread connection = new BluetoothConnectionThread(dev,
-                        this);
+                        this, CONNECTION_ATTEMPTS);
                 connection.start();
             }
 

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionThread.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionThread.java
@@ -50,23 +50,50 @@ class BluetoothConnectionThread extends Thread implements IConnection {
     private boolean m_Connected = false;
     private int m_MessagesSent = 0;
     private int m_MessagesReceived = 0;
+    private int m_NumConnectionAttempts = 1;
+    private int m_ConnectionAttemptsRemaining = 1;
 
     private BluetoothHeader m_BluetoothHeader;
     private ByteBuffer m_Payload;
 
     private BTSendThread m_SendThread;
 
-    public BluetoothConnectionThread(BluetoothDevice device, BluetoothConnectionMgr bcm) {
+    /**
+     * Instantiate a new Bluetooth connection with the given device.  This constructor is a client thread.
+     * @param device The device to try and connect to
+     * @param bcm The Bluetooth Connection manager we're using
+     * @param connectionAttempts How many connection attempts to make.  0 indicates we should only  make one
+     * connection attempt and never try to reconnect if we lose connection.  1 or more indicates how many many
+     * attempts we'll make before giving up.  If we lose connection we'll try the same number of times to
+     * re-establish the connection.  Less than 0 means we should continue to try and connect forever.
+     */
+    public BluetoothConnectionThread(BluetoothDevice device, BluetoothConnectionMgr bcm, int connectionAttempts) {
         android.util.Log.i(TAG, "BluetoothConnectionThread(device, ...)");
         m_Device = device;
         m_BluetoothConnectionMgr = new WeakReference<BluetoothConnectionMgr>(bcm);
+
+        // Always start with at least 1 connection attempt
+        m_ConnectionAttemptsRemaining = connectionAttempts == 0 ? 1 : connectionAttempts;
+        m_NumConnectionAttempts = connectionAttempts;
     }
 
+    /**
+     * Instantiate a new Bluetooth connection processing thread for the given connection.  This
+     * constructor wraps an already connected device.
+     * @param connection The connection to wrap
+     * @param bcm The Bluetooth Connection manager we're using
+     */
     public BluetoothConnectionThread(BluetoothSocket connection, BluetoothConnectionMgr bcm) {
         android.util.Log.i(TAG, "BluetoothConnectionThread(connection, ...)");
         m_Device = connection.getRemoteDevice();
         m_WrapSocket = connection;
         m_BluetoothConnectionMgr = new WeakReference<BluetoothConnectionMgr>(bcm);
+
+        // A server accepted socket should never try to reconnect - we rely on the client
+        // to reconnect and BluetoothManager broadcast intents to tell us when we should
+        // try to connect to a client device
+        m_ConnectionAttemptsRemaining = 0;
+        m_NumConnectionAttempts = 0;
     }
 
     /**
@@ -93,31 +120,43 @@ class BluetoothConnectionThread extends Thread implements IConnection {
     private void setup() {
         android.util.Log.i(TAG, "setup()");
 
-        try {
-            // Initialize an SPP socket - if we were passed a socket to wrap in the ctor
-            // then just initialize our IO streams etc.  If not then try to connect to the
-            // device we're mapped to...
-            BluetoothSocket newSocket = m_WrapSocket;
+        BluetoothSocket newSocket = m_WrapSocket;
 
-            if (newSocket == null) {
+        while (newSocket == null && (m_NumConnectionAttempts < 0 || --m_ConnectionAttemptsRemaining > 0)) {
+            try {
+                // Initialize an SPP socket - if we were passed a socket to wrap in the ctor
+                // then just initialize our IO streams etc.  If not then try to connect to the
+                // device we're mapped to...
                 newSocket = m_Device.createRfcommSocketToServiceRecord(SPP_UUID);
 
                 // Connect to the remote device.  This will block until connection, for up to about
                 // 12 seconds, or until we connect.
                 newSocket.connect();
+
+                setSocket(newSocket);
+
+            } catch (IOException ioe) {
+                android.util.Log.d(TAG, ioe.getMessage());
+                android.util.Log.i(TAG, "BluetoothSocket unable to connect!");
+                if ( m_NumConnectionAttempts == 0 || m_ConnectionAttemptsRemaining == 0 ) {
+                    requestHalt();
+                    android.util.Log.i(TAG, "Connection attempt failed.  Halting.");
+                }
+                else {
+                    android.util.Log.i(TAG, "Attempting to connect");
+                    newSocket = null;
+                }
             }
-
-            setSocket(newSocket);
-
-        } catch (IOException ioe) {
-            android.util.Log.d(TAG, ioe.getMessage());
-            android.util.Log.i(TAG, "BluetoothSocket unable to connect!");
-            requestHalt();
         }
     }
 
     private void setSocket(BluetoothSocket newSocket) throws IOException {
         synchronized (m_SocketLock) {
+
+            // Reset our connection attempts remaining and the socket we're
+            // wrapping so we attempt to reconnnect if we lose connection again later
+            m_ConnectionAttemptsRemaining = m_NumConnectionAttempts;
+            m_WrapSocket = null;
 
             m_Socket = newSocket;
 
@@ -211,9 +250,9 @@ class BluetoothConnectionThread extends Thread implements IConnection {
                 m_PayloadBuf = null;
             }
         } catch (IOException ioe) {
-            android.util.Log.i(TAG, "BT socket disconnected.  Cleaning up.");
+            android.util.Log.i(TAG, "BT socket disconnected.");
             ioe.printStackTrace();
-            requestHalt();
+            setup();
         }
     }
 


### PR DESCRIPTION
For any BT device we tried to connect to as a client (based on known pairings from BluetoothManager) on launch, now continuously try to connect.  And continuously attempt to reconnect if a connection is lost.  For socket connections made as a server we do not attempt to reconnect.

As before we do not kick off connections for newly bonded devices while the app is running.  You will have to restart the app again.

Overall performance impact here is untested. With three devices no appreciative difference noticed.  If you have a long list of paired devices you may experience excessive  battery drain and some slowness.  Recommend unpairing all unneeded BT devices before launching the app.

Also, as before, all incoming traffic is mirrored to all other connections.  Meaning you could connect two BT devices together and run into cross talk and unexpected results.