### PR TITLE
Retry Bluetooth Connections

### DIFF
--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/BaseConnectionMgr.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/BaseConnectionMgr.java
@@ -19,11 +19,6 @@ public abstract class BaseConnectionMgr extends Thread implements IConnectionMgr
     private Object m_Lock = new Object();   // Used as a private sync object for thread safety
     private ConnectionListenerHelper m_Listeners;
     private HashSet<IConnection> m_ActiveConnections = new HashSet<IConnection>();
-
-    private BaseConnectionMgr() {
-        m_Listeners = new ConnectionListenerHelper(TAG, this);
-    }
-
     private MessageHandler m_MsgHandler = MessageHandler.getInstance();
 
     /**
@@ -171,6 +166,9 @@ public abstract class BaseConnectionMgr extends Thread implements IConnectionMgr
             m_Listeners.onClosedConnection(closedConnection);
             removeConnection(closedConnection);
         }
+
+        // Offer a chance for reconnection to any interested managers
+        reconnect(closedConnection);
     }
 
     protected final void onMessage(IConnection srcConnection, NetworkHeader networkHeader,
@@ -205,5 +203,19 @@ public abstract class BaseConnectionMgr extends Thread implements IConnectionMgr
         synchronized (m_Lock) {
             m_ActiveConnections.remove(connection);
         }
+    }
+
+    /**
+     * Called when a connection is closed.  The base class never
+     * attempts to reconnect, but you may override this function
+     * in your own manager with your own reconnect logic.
+     *
+     * @param connection the connection that was just closed and is
+     *                   a candidate for reconnection.  DO NOT
+     *                   reuse this instance if you choose to
+     *                   reconnect.  Create a new IConnection instance
+     *                   and use addConnection as if it were new.
+     */
+    protected void reconnect(IConnection connection) {
     }
 }

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionMgr.java
@@ -46,7 +46,6 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
     private static final String TAG = BluetoothConnectionMgr.class.getSimpleName();
     private static final String SERVER_NAME = "AndroidServer";
     private static final int ACCEPT_TIMEOUT = 1000;
-    private static final int CONNECTION_ATTEMPTS = -1;  // Each attempt is about 12 seconds, -1 to go forever
 
     // Setup a constant with the well known SPP UUID
     private static final UUID SPP_UUID = UUID.fromString("00001101-0000-1000-8000-00805F9B34FB");
@@ -131,8 +130,7 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
         if (m_BluetoothAdapter != null) {
             Set<BluetoothDevice> devs = m_BluetoothAdapter.getBondedDevices();
             for (BluetoothDevice dev : devs) {
-                BluetoothConnectionThread connection = new BluetoothConnectionThread(dev,
-                        this, CONNECTION_ATTEMPTS);
+                BluetoothConnectionThread connection = new BluetoothConnectionThread(dev, this);
                 connection.start();
             }
 
@@ -155,15 +153,13 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
             // All we're going to do here is listen for incoming connections
             // and spawn off receiver conections
             BluetoothSocket newConnection = null;
-            android.util.Log.v(TAG, "accept()");
             newConnection = m_ServerSocket.accept( ACCEPT_TIMEOUT );
-
-            android.util.Log.i(TAG, "Accepting connection to " + newConnection.getRemoteDevice().getName());
-
             BluetoothConnectionThread connection = new BluetoothConnectionThread(newConnection,
                     this);
             connection.start();
 
+            // TODO: Turns out a Bluetooth Server socket is only good for one connection
+            // Create a new server socket for the next run.
 
         } catch (IOException ioe) {
             // Assuming we just timed out here and this is ok - may need to revisit this if we find
@@ -175,6 +171,19 @@ public class BluetoothConnectionMgr extends BaseConnectionMgr implements IConnec
     @Override
     protected void cleanup() {
         android.util.Log.i(TAG, "cleanup()");
+    }
+
+    @Override
+    protected void reconnect(IConnection connection) {
+        android.util.Log.d(TAG, "reconnect("+connection.getDescription() + ")");
+
+        if ( connection instanceof BluetoothConnectionThread ) {
+            BluetoothConnectionThread btConnection = (BluetoothConnectionThread)connection;
+
+            BluetoothConnectionThread connThread =
+                    new BluetoothConnectionThread(btConnection.getDevice(), this);
+            connThread.start();
+        }
     }
 
     //

--- a/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionThread.java
+++ b/AndroidServer/msgserver/src/main/java/msgtools/milesengineering/msgserver/connectionmgr/bluetooth/BluetoothConnectionThread.java
@@ -90,6 +90,15 @@ class BluetoothConnectionThread extends Thread implements IConnection {
         cleanup();
     }
 
+    /**
+     * Get the BluetoothDevice we're connected to
+     *
+     * @return A BluetoothDevice instance for the remote device
+     */
+    public BluetoothDevice getDevice() {
+        return m_Device;
+    }
+
     private void setup() {
         android.util.Log.i(TAG, "setup()");
 


### PR DESCRIPTION
Two cases:
1. We were connected and then get disconnected
2. We failed to connect in any case 

Note that we attempt a reconnect irrespective of whether or not we made the initial connection request (i.e. incoming server socket connections are also re-attempted ).  Not the cleanest solution, but shouldn't have any negative impacts.

Ideally our design pushes everything into the base connection manager with more robust reconnect management, however in the interest of time and simplicity I coded most everything into the Bluetooth Manager.