### PR TITLE
Add Bluetooth RFCOMM-based communication to msgserver

### DIFF
--- a/msgtools/parser/test/TestCpp.py
+++ b/msgtools/parser/test/TestCpp.py
@@ -47,11 +47,14 @@ uint8_t GetFieldD() const
     return Get_uint8_t(&m_data[11]);
 }""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (0.0 to 215.355)*/
 float GetBitsA() const
 {
     return (float((GetFieldD() >> 0) & 0xf) * 14.357f);
-}""")
+}
+#endif
+""")
         expected.append("""\
 /*  , (0 to 7)*/
 EnumA GetBitsB() const
@@ -65,17 +68,23 @@ uint8_t GetBitsC() const
     return (GetFieldD() >> 7) & 0x1;
 }""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (0.0 to 10.0)*/
 float GetFieldE() const
 {
     return Get_float(&m_data[12]);
-}""")
+}
+#endif
+""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (1.828 to 176946.328)*/
 float GetFieldF() const
 {
     return ((float(Get_uint16_t(&m_data[16])) * 2.7f) + 1.828f);
-}""")
+}
+#endif
+""")
         expected.append("""\
 /*  m/s, (0 to 4294967295)*/
 void SetFieldA(uint32_t value)
@@ -107,11 +116,14 @@ void SetFieldD(uint8_t value)
     Set_uint8_t(&m_data[11], value);
 }""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (0.0 to 215.355)*/
 void SetBitsA(float value)
 {
     SetFieldD((GetFieldD() & ~(0xf << 0)) | (((uint8_t)(value / 14.357f) & 0xf) << 0));
-}""")
+}
+#endif
+""")
         expected.append("""\
 /*  , (0 to 7)*/
 void SetBitsB(EnumA value)
@@ -125,17 +137,23 @@ void SetBitsC(uint8_t value)
     SetFieldD((GetFieldD() & ~(0x1 << 7)) | ((value & 0x1) << 7));
 }""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (0.0 to 10.0)*/
 void SetFieldE(float value)
 {
     Set_float(&m_data[12], value);
-}""")
+}
+#endif
+""")
         expected.append("""\
+#ifndef DISABLE_FLOAT_ACCESSORS
 /*  , (1.828 to 176946.328)*/
 void SetFieldF(float value)
 {
     Set_uint16_t(&m_data[16], (uint16_t)((value - 1.828f) / 2.7f));
-}""")
+}
+#endif
+""")
         expected.append("""\
 /*  , (0 to 255)*/
 uint8_t* FieldC()

--- a/msgtools/server/BluetoothRFCOMM.py
+++ b/msgtools/server/BluetoothRFCOMM.py
@@ -1,0 +1,104 @@
+from PyQt5 import QtCore, QtWidgets
+from PyQt5.QtCore import QObject
+
+from msgtools.lib.messaging import Messaging
+from BluetoothHeader import BluetoothHeader
+from NetworkHeader import NetworkHeader
+
+NHS = NetworkHeader.SIZE
+BTHS = BluetoothHeader.SIZE
+
+# We require bluez, available on Windows and Linux
+import bluetooth
+import threading
+import select
+import time
+
+class BluetoothRFCOMMConnection(QObject):
+    disconnected = QtCore.pyqtSignal(object)
+    messagereceived = QtCore.pyqtSignal(object)
+    statusUpdate = QtCore.pyqtSignal(str)
+
+    def __init__(self, deviceBTAddr):
+        super(BluetoothRFCOMMConnection, self).__init__(None)
+
+        self.removeClient = QtWidgets.QPushButton("Remove")
+        self.removeClient.pressed.connect(lambda: self.socket.close())
+        self.statusLabel = QtWidgets.QLabel()
+        self.subscriptions = {}
+        self.subMask = 0
+        self.subValue = 0
+        self.isHardwareLink = True
+        self.basetime = time.time()
+        
+        services = bluetooth.find_service(address=deviceBTAddr,
+                                          uuid='00001101-0000-1000-8000-00805F9B34FB')
+        if len(services)<=0:
+            pass
+        
+        self.socket = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
+        self.socket.connect((deviceBTAddr, services[0]['port']))
+        #self.socket.disconnected.connect(self.onDisconnected)
+
+        self.btsock_buffer = b''
+        self.btsock_outgoing = b''
+
+        self.hdrTranslator = Messaging.HeaderTranslator(BluetoothHeader, NetworkHeader)
+        
+        self.name = "Bluetooth RFCOMM " + deviceBTAddr
+        self.statusLabel.setText(self.name)
+
+        self.thread = threading.Thread(target=self.rfcommThread)
+        self.thread.daemon = True
+        self.thread.start()
+
+    def widget(self, index):
+        if index == 0:
+            return self.removeClient
+        if index == 1:
+            return self.statusLabel
+        return None
+
+    def rfcommThread(self):
+        while True:
+            ret = select.select([self.socket],
+                                [self.socket],
+                                [],
+                                0.1)
+            if len(ret[2]) > 0:
+                #self.statusUpdate.emit("some message?")
+                self.onDisconnected()
+                return
+
+            if len(ret[0]) > 0:
+                # we've got data to read
+                self.btsock_buffer += self.socket.recv(4096)
+
+            if len(self.btsock_outgoing)>0 and len(ret[1])>0:
+                sent = self.socket.send(self.btsock_outgoing)
+                self.btsock_outgoing = self.btsock_outgoing[sent:]
+
+            while len(self.btsock_buffer) >= BTHS:
+                hdr = BluetoothHeader(self.btsock_buffer[0:BTHS])
+                total_len = BTHS + hdr.GetDataLength()
+                if len(self.btsock_buffer) >= total_len:
+                    # we've got enough data for the whole message
+                    hdr = BluetoothHeader(self.btsock_buffer)
+                    self.btsock_buffer = self.btsock_buffer[total_len:]
+                    
+                    networkMsg = self.hdrTranslator.translate(hdr)
+                    
+                    self.messagereceived.emit(networkMsg)
+                else:
+                    # we don't quite have enough data for a whole message
+                    break
+
+    def onDisconnected(self):
+        self.disconnected.emit(self)
+
+    def sendMsg(self, networkMsg):
+        btMsg = self.hdrTranslator.translate(networkMsg)
+        # if we can't translate the message, just return
+        if btMsg == None:
+            return
+        self.btsock_outgoing += btMsg.rawBuffer().raw

--- a/msgtools/server/BluetoothRFCOMMQt.py
+++ b/msgtools/server/BluetoothRFCOMMQt.py
@@ -1,0 +1,80 @@
+from PyQt5 import QtCore, QtGui, QtWidgets, QtNetwork
+from PyQt5.QtCore import QObject
+
+from msgtools.lib.messaging import Messaging
+from BluetoothHeader import BluetoothHeader
+from NetworkHeader import NetworkHeader
+
+# We require Qt Bluetooth support, available on Linux and Macs(?)
+
+class BluetoothRFCOMMQtConnection(QObject):
+    disconnected = QtCore.pyqtSignal(object)
+    messagereceived = QtCore.pyqtSignal(object)
+    statusUpdate = QtCore.pyqtSignal(str)
+
+    def __init__(self, socket):
+        super(BluetoothRFCOMMConnection, self).__init__(None)
+
+        self.removeClient = QtWidgets.QPushButton("Remove")
+        self.removeClient.pressed.connect(lambda: self.socket.close())
+        self.statusLabel = QtWidgets.QLabel()
+        self.subscriptions = {}
+        self.subMask = 0
+        self.subValue = 0
+        self.isHardwareLink = True
+
+        self.socket = socket
+        self.socket.readyRead.connect(self.onReadyRead)
+        self.socket.disconnected.connect(self.onDisconnected)
+
+        self.hdrTranslator = Messaging.HeaderTranslator(BluetoothHeader, NetworkHeader)
+        
+        self.rxBuffer = bytearray()
+
+        self.name = "Bluetooth RFCOMM " + self.socket.peerAddress().toString()
+        self.statusLabel.setText(self.name)
+
+    def widget(self, index):
+        if index == 0:
+            return self.removeClient
+        if index == 1:
+            return self.statusLabel
+        return None
+            
+    def onReadyRead(self):
+        inputStream = QtCore.QDataStream(self.socket)
+
+        while(1):
+            if len(self.rxBuffer) < BluetoothHeader.SIZE:
+                if self.socket.bytesAvailable() < BluetoothHeader.SIZE:
+                    return
+                self.rxBuffer += inputStream.readRawData(BluetoothHeader.SIZE - len(self.rxBuffer))
+
+            if len(self.rxBuffer) >= BluetoothHeader.SIZE:
+                hdr = BluetoothHeader(self.rxBuffer)
+                bodyLen = hdr.GetDataLength()
+                if len(self.rxBuffer)+self.socket.bytesAvailable() < BluetoothHeader.SIZE + bodyLen:
+                    return
+
+                self.rxBuffer += inputStream.readRawData(BluetoothHeader.SIZE + bodyLen - len(self.rxBuffer))
+
+                # create a new header object with the appended body
+                btHdr = BluetoothHeader(self.rxBuffer)
+
+                # if we got this far, we have a whole message! So, emit the signal
+                networkMsg = self.hdrTranslator.translate(btHdr)
+
+                self.messagereceived.emit(networkMsg)
+
+                # then clear the buffer, so we start over on the next message
+                self.rxBuffer = bytearray()
+
+    def onDisconnected(self):
+        self.disconnected.emit(self)
+
+    def sendMsg(self, networkMsg):
+        btMsg = self.hdrTranslator.translate(networkMsg)
+        # if we can't translate the message, just return
+        if btMsg == None:
+            return
+        self.socket.write(btMsg.rawBuffer().raw)

--- a/msgtools/server/server.py
+++ b/msgtools/server/server.py
@@ -27,13 +27,13 @@ class MessageServer(QtWidgets.QMainWindow):
         msgLoadDir = None
         # need a way to make serial= and serial both work!
         try:
-            options = ['serial=', 'bluetoothSPP=', 'plugin=', 'port=', 'msgdir=']
+            options = ['serial=', 'bluetoothSPP=', 'bluetoothRFCOMM=', 'bluetoothRFCOMMQt=', 'plugin=', 'port=', 'msgdir=']
             self.optlist, args = getopt.getopt(sys.argv[1:], '', options)
         except getopt.GetoptError:
             pass
 
         try:
-            options = ['serial', 'bluetoothSPP=', 'plugin=', 'port=', 'msgdir=']
+            options = ['serial', 'bluetoothSPP=', 'bluetoothRFCOMM=', 'bluetoothRFCOMMQt=', 'plugin=', 'port=', 'msgdir=']
             self.optlist, args = getopt.getopt(sys.argv[1:], '', options)
         except getopt.GetoptError:
             pass
@@ -80,6 +80,21 @@ class MessageServer(QtWidgets.QMainWindow):
                 self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
                 self.onNewConnection(self.bluetoothPort)
                 self.bluetoothPort.start()
+            elif opt[0] == '--bluetoothRFCOMM':
+                from msgtools.server.BluetoothRFCOMM import BluetoothRFCOMMConnection
+                btDeviceAddr = opt[1]
+                self.bluetoothPort = BluetoothRFCOMMConnection(btDeviceAddr)
+                self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
+                self.onNewConnection(self.bluetoothPort)
+            elif opt[0] == '--bluetoothRFCOMMQt':
+                from msgtools.server.BluetoothRFCOMMQt import BluetoothRFCOMMQtConnection
+                from PyQt5 import QtBluetooth
+                btHost = opt[1]
+                self.btSocket = QtBluetooth.QBluetoothSocket(QtBluetooth.QBluetoothServiceInfo.RfcommProtocol)
+                self.btSocket.connectToService(QtBluetooth.QBluetoothAddress(btHost), 8)
+                self.bluetoothPort = BluetoothRFCOMMQtConnection(self.btSocket)
+                self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
+                self.onNewConnection(self.bluetoothPort)
             elif opt[0] == '--plugin':
                 filename = opt[1]
                 import os


### PR DESCRIPTION
adds --bluetoothRFCOMM=macaddr and --bluetoothRFCOMMQt=macaddr arguments to msgserver.

the Qt version uses Qt's bluetooth, which should work on mac and linux. the non-Qt version uses bluez, which should work on windows and linux.

both versions determine the RFCOMM port to use by scanning the device for an SPP service, and taking the first one found.