### PR TITLE
allow exact RFCOMM port specification for bluetooth connections

### DIFF
--- a/msgtools/server/BluetoothRFCOMM.py
+++ b/msgtools/server/BluetoothRFCOMM.py
@@ -19,7 +19,7 @@ class BluetoothRFCOMMConnection(QObject):
     messagereceived = QtCore.pyqtSignal(object)
     statusUpdate = QtCore.pyqtSignal(str)
 
-    def __init__(self, deviceBTAddr):
+    def __init__(self, deviceBTAddr, deviceBTPort=None):
         super(BluetoothRFCOMMConnection, self).__init__(None)
 
         self.removeClient = QtWidgets.QPushButton("Remove")
@@ -31,13 +31,16 @@ class BluetoothRFCOMMConnection(QObject):
         self.isHardwareLink = True
         self.basetime = time.time()
         
-        services = bluetooth.find_service(address=deviceBTAddr,
-                                          uuid='00001101-0000-1000-8000-00805F9B34FB')
-        if len(services)<=0:
-            pass
+        if deviceBTPort is None:
+            services = bluetooth.find_service(address=deviceBTAddr,
+                                              uuid='00001101-0000-1000-8000-00805F9B34FB')
+            if len(services)<=0:
+                deviceBTPort = 8
+            else:
+                deviceBTPort = services[0]['port']
         
         self.socket = bluetooth.BluetoothSocket(bluetooth.RFCOMM)
-        self.socket.connect((deviceBTAddr, services[0]['port']))
+        self.socket.connect((deviceBTAddr, deviceBTPort))
         #self.socket.disconnected.connect(self.onDisconnected)
 
         self.btsock_buffer = b''

--- a/msgtools/server/server.py
+++ b/msgtools/server/server.py
@@ -82,16 +82,23 @@ class MessageServer(QtWidgets.QMainWindow):
                 self.bluetoothPort.start()
             elif opt[0] == '--bluetoothRFCOMM':
                 from msgtools.server.BluetoothRFCOMM import BluetoothRFCOMMConnection
-                btDeviceAddr = opt[1]
-                self.bluetoothPort = BluetoothRFCOMMConnection(btDeviceAddr)
+                btArgs = opt[1].split(",")
+                if len(btArgs)>1:
+                    btArgs[1] = int(btArgs[1])
+                self.bluetoothPort = BluetoothRFCOMMConnection(*btArgs)
                 self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
                 self.onNewConnection(self.bluetoothPort)
             elif opt[0] == '--bluetoothRFCOMMQt':
                 from msgtools.server.BluetoothRFCOMMQt import BluetoothRFCOMMQtConnection
                 from PyQt5 import QtBluetooth
-                btHost = opt[1]
+                btArgs = opt[1].split(",")
+                btHost = btArgs[0]
+                if len(btArgs)>1:
+                    btPort = int(btArgs[1])
+                else:
+                    btPort = 8
                 self.btSocket = QtBluetooth.QBluetoothSocket(QtBluetooth.QBluetoothServiceInfo.RfcommProtocol)
-                self.btSocket.connectToService(QtBluetooth.QBluetoothAddress(btHost), 8)
+                self.btSocket.connectToService(QtBluetooth.QBluetoothAddress(btHost), btPort)
                 self.bluetoothPort = BluetoothRFCOMMQtConnection(self.btSocket)
                 self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
                 self.onNewConnection(self.bluetoothPort)


### PR DESCRIPTION
In case `find_services` doesn't do the job, or you want to try talking to arbitrary ports, this adds the ability to specify an RFCOMM port: `--bluetoothRFCOMM=aa:bb:cc:dd:ee:ff,8` for instance.