### PR TITLE
Improve Command Line Help and Error Detection

### DIFF
--- a/mk/codegen.mk
+++ b/mk/codegen.mk
@@ -15,38 +15,38 @@ MSG_FILES := $(shell cd $(mdir) && find * -iname \*.yaml)
 .PHONY: python cpp c java js swift matlab html check
 
 python:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Python python  Template.py HeaderTemplate.py
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Python python
 
 cpp:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Cpp cpp  Template.h HeaderTemplate.h
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Cpp cpp
 
 c:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/C c  Template.h HeaderTemplate.h
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/C c
 
 $(MSGDIR)/Dart/pubspec.yaml:
 	@mkdir -p $(@D)
 	echo 'name: messages\ndescription: Auto-generated Dart code from MsgTools, based on YAML message definitions.' > $@
 
 dart: | $(MSGDIR)/Dart/pubspec.yaml
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Dart/lib dart  Template.dart HeaderTemplate.dart
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Dart/lib dart
 
 dartlint:
 	cd $(MSGDIR)/Dart ; flutter analyze > lint.txt
 
 java:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Java java  Template.java HeaderTemplate.java
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Java java
 
 js:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Javascript javascript  Template.js HeaderTemplate.js
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Javascript javascript
 
 swift:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Swift swift  Template.swift HeaderTemplate.swift
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Swift swift
 
 matlab:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Matlab/+Messages matlab  Template.m HeaderTemplate.m
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Matlab/+Messages matlab
 
 html:
-	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Html html  Template.html HeaderTemplate.html
+	$(PARSER) $(mdir) $(call CYGPATH,$(MSGDIR))/Html html
 	@find $(MSGDIR)/Html -type d -print0 | xargs -n 1 -0 cp $(CG_DIR)html/bootstrap.min.css
 
 check: $(DIGEST)

--- a/msgtools/goodlistener/goodlistener.py
+++ b/msgtools/goodlistener/goodlistener.py
@@ -33,7 +33,7 @@ class GoodListener(msgtools.lib.gui.Gui):
         parser.add_argument('inputfiles', nargs='+', help='''Optional results file, followed by
             the log file to process.''')
 
-        parser = msgtools.lib.gui.Gui.getArgParser(parser, skipFiles = True)
+        parser = msgtools.lib.gui.Gui.getArgParser('', parser, skipFiles = True)
         args = parser.parse_args()
 
         # Override args to line this up for file processing in our shared class

--- a/msgtools/goodlistener/goodlistener.py
+++ b/msgtools/goodlistener/goodlistener.py
@@ -18,6 +18,9 @@ except ImportError:
     from msgtools.lib.messaging import Messaging
 import msgtools.lib.gui
 
+DESCRIPTION='''Good listener listens for messages and tests to ensure they are
+    valid.'''
+
 class MsgTimeoutError(Exception):
     def __init__(self, msgName, timeout):
         self.msgName = msgName
@@ -29,16 +32,21 @@ class GoodListener(msgtools.lib.gui.Gui):
     MSG_TIMEOUT = 10
     def __init__(self, ThreadClass, parent=None):
 
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
         parser.add_argument('inputfiles', nargs='+', help='''Optional results file, followed by
             the log file to process.''')
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
         args = parser.parse_args()
 
         # Override args to line this up for file processing in our shared class
         args.ip = None
         args.port = None
-        args.files = []
+
+        # Stuff base App arguments
+        args.lastserial = False
+        args.serial = None
+        args.msg = None
+        args.msgdir = None
+
 
         if len(args.inputfiles) > 1:
             resultsFilename = args.inputfiles[0]

--- a/msgtools/goodlistener/goodlistener.py
+++ b/msgtools/goodlistener/goodlistener.py
@@ -32,8 +32,7 @@ class GoodListener(msgtools.lib.gui.Gui):
         parser = argparse.ArgumentParser()
         parser.add_argument('inputfiles', nargs='+', help='''Optional results file, followed by
             the log file to process.''')
-
-        parser = msgtools.lib.gui.Gui.getArgParser('', parser, skipFiles = True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
         args = parser.parse_args()
 
         # Override args to line this up for file processing in our shared class

--- a/msgtools/goodlistener/goodlistener.py
+++ b/msgtools/goodlistener/goodlistener.py
@@ -41,13 +41,6 @@ class GoodListener(msgtools.lib.gui.Gui):
         args.ip = None
         args.port = None
 
-        # Stuff base App arguments
-        args.lastserial = False
-        args.serial = None
-        args.msg = None
-        args.msgdir = None
-
-
         if len(args.inputfiles) > 1:
             resultsFilename = args.inputfiles[0]
             logFileName = None if len(args.inputfiles) < 2 else args.inputfiles[2]

--- a/msgtools/goodlistener/goodlistener.py
+++ b/msgtools/goodlistener/goodlistener.py
@@ -2,6 +2,7 @@
 import sys
 import queue
 import time
+import argparse
 
 from PyQt5 import QtCore, QtGui, QtWidgets
 from PyQt5.QtCore import QTimer
@@ -26,20 +27,34 @@ class MsgTimeoutError(Exception):
 
 class GoodListener(msgtools.lib.gui.Gui):
     MSG_TIMEOUT = 10
-    def __init__(self, argv, ThreadClass, parent=None):
-        if(len(argv) < 2):
-            exit('''
-Invoke like this
-    ./path/to/GoodListener.py [RESULTS] [LOG]
-    
-where RESULTS and LOG are the optional results and log files.
-''')
+    def __init__(self, ThreadClass, parent=None):
+
+        parser = argparse.ArgumentParser()
+        parser.add_argument('inputfiles', nargs='+', help='''Optional results file, followed by
+            the log file to process.''')
+
+        parser = msgtools.lib.gui.Gui.getArgParser(parser, skipFiles = True)
+        args = parser.parse_args()
+
+        # Override args to line this up for file processing in our shared class
+        args.ip = None
+        args.port = None
+        args.files = []
+
+        if len(args.inputfiles) > 1:
+            resultsFilename = args.inputfiles[0]
+            logFileName = None if len(args.inputfiles) < 2 else args.inputfiles[2]
+        else:
+            resultsFilename = None
+            logFileName = args.inputfiles[1]
+
+        args.connectionType = 'file'
+        args.connectionName = logFilename
+
         appName = "Good Listener 0.1, " + ThreadClass.__name__
-        msgtools.lib.gui.Gui.__init__(self, appName, [argv[0],"file"]+argv[1:], [], parent)
+        msgtools.lib.gui.Gui.__init__(self, appName, args, parent)
         
-        resultsFilename = argv[1]
-        logFileName = argv[2]
-        
+
         self.statusWindow = QtWidgets.QPlainTextEdit(self)
         doc = self.statusWindow.document()
         font = doc.defaultFont()
@@ -142,7 +157,7 @@ class MyTest(ScriptThread):
 
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
-    listener = GoodListener(sys.argv, MyTest)
+    listener = GoodListener(MyTest)
     listener.show()
     sys.exit(app.exec_())
 

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -20,7 +20,7 @@ DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect mes
 class MsgInspector(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser = msgtools.lib.gui.Gui.getArgParser(parent=parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.getArgParser(DESCRIPTION, parent=parser, skipFiles=True)
         args=parser.parse_args()
 
         msgtools.lib.gui.Gui.__init__(self, "Message Inspector 0.1", args, parent)

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 import struct
 import sys
+import argparse
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 try:
@@ -12,9 +13,17 @@ except ImportError:
     from msgtools.lib.messaging import Messaging
 import msgtools.lib.gui
 
+DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect messages as they arrive.
+    It is similar to MsgScope but presents data in a time linear format with compact details, with 
+    each message type grouped.'''
+
 class MsgInspector(msgtools.lib.gui.Gui):
-    def __init__(self, argv, parent=None):
-        msgtools.lib.gui.Gui.__init__(self, "Message Inspector 0.1", argv, [], parent)
+    def __init__(self, parent=None):
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+        parser = msgtools.lib.gui.Gui.getArgParser(parent=parser, skipFiles=True)
+        args=parser.parse_args()
+
+        msgtools.lib.gui.Gui.__init__(self, "Message Inspector 0.1", args, parent)
         
         # event-based way of getting messages
         self.RxMsg.connect(self.ProcessMessage)
@@ -96,7 +105,7 @@ class MsgInspector(msgtools.lib.gui.Gui):
 
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
-    msgApp = MsgInspector(sys.argv)
+    msgApp = MsgInspector()
     msgApp.show()
     sys.exit(app.exec_())
 

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -14,8 +14,8 @@ except ImportError:
 import msgtools.lib.gui
 
 DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect messages as they arrive.
-    It is similar to MsgScope but presents data in a time linear format with compact details, with 
-    each message type grouped.'''
+    It is similar to MsgScope but presents data in a time linear format with compact details.  Each message
+    type grouped into it's own tab'''
 
 class MsgInspector(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -20,7 +20,7 @@ DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect mes
 class MsgInspector(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
         args=parser.parse_args()
 
         msgtools.lib.gui.Gui.__init__(self, "Message Inspector 0.1", args, parent)

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -20,7 +20,7 @@ DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect mes
 class MsgInspector(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser = msgtools.lib.gui.Gui.getArgParser(DESCRIPTION, parent=parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
         args=parser.parse_args()
 
         msgtools.lib.gui.Gui.__init__(self, "Message Inspector 0.1", args, parent)

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -56,6 +56,13 @@ class App(QtWidgets.QMainWindow):
                parent ArgumentParser and provide additional options.
         '''
 
+        # If the caller skips adding base arguments we need to patch up args
+        args.lastserial = False if hasattr(args, 'lastserial') == False else args.lastserial
+        args.serial = None if hasattr(args, 'serial') == False else args.serial
+        args.msg = None if hasattr(args, 'msg') == False else args.msg
+        args.msgdir = None if hasattr(args, 'msgdir') == False else args.msgdir
+
+
         # default to Network, unless we have a input filename that contains .txt
         headerName = "NetworkHeader"
         if args.serial or (hasattr(args, 'files') and len(args.files) > 0 and 

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -38,7 +38,7 @@ class App(QtWidgets.QMainWindow):
                     This parameter is overridden by the --ip and --port options.''')
         parser.add_argument('--ip', help='The IP address for a socket connection.   Overrides connectionName.')
         parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
-        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields´.  Presently unsupported.')
+#        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
         parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader. Overrides files.')
         parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -21,14 +21,14 @@ class App(QtWidgets.QMainWindow):
     connectionChanged = QtCore.pyqtSignal(bool)
 
     @classmethod
-    def getArgParser(cls, parent=None, skipFiles=False):
+    def getArgParser(cls, description, epilog=None, parent=None, skipFiles=False):
         '''Retrieve an Arg Parser outlining the command line options
         this class relies on.  This is provided so you can extend
         the parser with your own higher level arguments.
         
         parent - an ArgParser to use as a parent to the one
         for this class.'''
-        parser = argparse.ArgumentParser(parents=[parent], add_help=False)
+        parser = argparse.ArgumentParser(description=description, epilog=epilog, parents=[parent], add_help=False)
         parser.add_argument('--connectionType', choices=['socket', 'qtsocket', 'file'], default='qtsocket',
             help='Specify the type of connection we are establishing as a message pipe/source.')
         parser.add_argument('--connectionName', default='127.0.0.1:5678',

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -21,14 +21,12 @@ class App(QtWidgets.QMainWindow):
     connectionChanged = QtCore.pyqtSignal(bool)
 
     @classmethod
-    def getArgParser(cls, description, epilog=None, parent=None, skipFiles=False):
-        '''Retrieve an Arg Parser outlining the command line options
-        this class relies on.  This is provided so you can extend
-        the parser with your own higher level arguments.
-        
-        parent - an ArgParser to use as a parent to the one
-        for this class.'''
-        parser = argparse.ArgumentParser(description=description, epilog=epilog, parents=[parent], add_help=False)
+    def addBaseArguments(cls, parser, skipFiles=False):
+        '''
+        Adds base app arguments to the provided ArgParser
+        skipFiles - if True we won't provide an agument for a files list
+        returns the parser
+        '''
         parser.add_argument('--connectionType', choices=['socket', 'qtsocket', 'file'], default='qtsocket',
             help='Specify the type of connection we are establishing as a message pipe/source.')
         parser.add_argument('--connectionName', default='127.0.0.1:5678',
@@ -40,7 +38,7 @@ class App(QtWidgets.QMainWindow):
         parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
         parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
-        parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader. Overrides files.')
+        parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader.')
 
         if skipFiles is False:
             parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -78,35 +78,30 @@ class App(QtWidgets.QMainWindow):
         # directory to load messages from.
         msgLoadDir = None
 
-        # need better handling of command line arguments for case when there is only one arg and it's a filename
-        if(len(sys.argv) == 3 and sys.argv[2].lower().endswith((".txt",".log"))):
-            self.connectionType = "file"
-            self.connectionName = argv[2]
-        else:
-            # connection modes
-            ip = ""
-            port = ""
+        # connection modes
+        ip = ""
+        port = ""
 
-            if args.connectionType is not None:
-                self.connectionType = args.connectionType
-            if args.connectionName is not None:
-                self.connectionName = args.connectionName
-            if args.ip is not None:
-                ip = args.ip
-            if args.port is not None:
-                port = args.port
-            if args.msg is not None:
-                option = args.msg.split('/')
-                self.allowedMessages.append(option[0])
-                if len(option) > 1:
-                    self.keyFields[option[0]] = option[1]
-                print("only allowing msg " + str(option))
-            if args.msgdir:
-                msgLoadDir = args.msgdir
-            
-            # if either --ip or --port were used, override connectionName
-            if args.ip is not None or args.port is not None:
-                self.connectionName = str(ip)+":"+str(port)
+        if args.connectionType is not None:
+            self.connectionType = args.connectionType
+        if args.connectionName is not None:
+            self.connectionName = args.connectionName
+        if args.ip is not None:
+            ip = args.ip
+        if args.port is not None:
+            port = args.port
+        if args.msg is not None:
+            option = args.msg.split('/')
+            self.allowedMessages.append(option[0])
+            if len(option) > 1:
+                self.keyFields[option[0]] = option[1]
+            print("only allowing msg " + str(option))
+        if args.msgdir:
+            msgLoadDir = args.msgdir
+        
+        # if either --ip or --port were used, override connectionName
+        if args.ip is not None or args.port is not None:
+            self.connectionName = str(ip)+":"+str(port)
         
         # initialize the read function to None, so it's not accidentally called
         self.readBytesFn = None
@@ -177,10 +172,11 @@ class App(QtWidgets.QMainWindow):
         elif(self.connectionType.lower() == "file"):
             try:
                 self.connection = open(self.connectionName, 'rb')
+                self.readBytesFn = self.connection.read
+                self.sendBytesFn = self.connection.write
             except IOError:
                 print("\nERROR!\ncan't open file ", self.connectionName)
-            self.readBytesFn = self.connection.read
-            self.sendBytesFn = self.connection.write
+                sys.exit(1)
         else:
             print("\nERROR!\nneed to specify socket or file")
             sys.exit()

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -21,7 +21,7 @@ class App(QtWidgets.QMainWindow):
     connectionChanged = QtCore.pyqtSignal(bool)
 
     @classmethod
-    def getArgParser(cls, parent=None):
+    def getArgParser(cls, parent=None, skipFiles=False):
         '''Retrieve an Arg Parser outlining the command line options
         this class relies on.  This is provided so you can extend
         the parser with your own higher level arguments.
@@ -41,8 +41,10 @@ class App(QtWidgets.QMainWindow):
 #        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
         parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader. Overrides files.')
-        parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  
-                    Any file with a .txt extension will trigger the use of a SerialHeader instead of a NetworkHeader.''')
+
+        if skipFiles is False:
+            parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  
+                        Any file with a .txt extension will trigger the use of a SerialHeader instead of a NetworkHeader.''')
 
         return parser
     
@@ -90,12 +92,12 @@ class App(QtWidgets.QMainWindow):
             ip = args.ip
         if args.port is not None:
             port = args.port
-        if args.msg is not None:
-            option = args.msg.split('/')
-            self.allowedMessages.append(option[0])
-            if len(option) > 1:
-                self.keyFields[option[0]] = option[1]
-            print("only allowing msg " + str(option))
+        # if args.msg is not None:
+        #     option = args.msg.split('/')
+        #     self.allowedMessages.append(option[0])
+        #     if len(option) > 1:
+        #         self.keyFields[option[0]] = option[1]
+        #     print("only allowing msg " + str(option))
         if args.msgdir:
             msgLoadDir = args.msgdir
         

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -1,7 +1,7 @@
 import socket
 import os
 import sys
-import getopt
+import argparse
 
 if sys.version_info<(3,4):
     raise SystemExit('''\n\nSorry, this code need Python 3.4 or higher.\n
@@ -19,8 +19,48 @@ class App(QtWidgets.QMainWindow):
     RxMsg = QtCore.pyqtSignal(object)
     statusUpdate = QtCore.pyqtSignal(str)
     connectionChanged = QtCore.pyqtSignal(bool)
+
+    @classmethod
+    def getArgParser(cls, parent=None):
+        '''Retrieve an Arg Parser outlining the command line options
+        this class relies on.  This is provided so you can extend
+        the parser with your own higher level arguments.
+        
+        parent - an ArgParser to use as a parent to the one
+        for this class.'''
+        parser = argparse.ArgumentParser(parents=[parent], add_help=False)
+        parser.add_argument('--connectionType', choices=['socket', 'qtsocket', 'file'], default='qtsocket',
+            help='Specify the type of connection we are establishing as a message pipe/source.')
+        parser.add_argument('--connectionName', default='127.0.0.1:5678',
+            help='''The connection name.  For socket connections this is an IP and port e.g. 127.0.0.1:5678.  
+                    You may prepend ws:// to indicate you want to use a Websocket instead.  For file 
+                    connection types, this is the filename to use as a message source.
+                    This parameter is overridden by the --ip and --port options.''')
+        parser.add_argument('--ip', help='The IP address for a socket connection.   Overrides connectionName.')
+        parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
+        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields´.  Presently unsupported.')
+        parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
+        parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader. Overrides files.')
+        parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  
+                    Any file with a .txt extension will trigger the use of a SerialHeader instead of a NetworkHeader.''')
+
+        return parser
     
-    def __init__(self, name, headerName, argv, options):
+    def __init__(self, name, args):
+        '''Initializer - this is used more as a decorator in the MsgTools suite than an actual
+        standalone class.
+
+        name - the name of the application - usually displayed in the UI window header
+        args - argparse.Namespace of command line options.  See getArgParser for what we provide
+               by default as part of this base app framework.  A command line tool may act as a 
+               parent ArgumentParser and provide additional options.
+        '''
+
+        # default to Network, unless we have a input filename that contains .txt
+        headerName = "NetworkHeader"
+        if args.serial or (len(args.files) > 0 and any(".txt" in s for s in args.files) or any(".TXT" in s for s in args.files)):
+            headerName = "SerialHeader"
+
         self.name = name
         
         # persistent settings
@@ -39,39 +79,33 @@ class App(QtWidgets.QMainWindow):
         msgLoadDir = None
 
         # need better handling of command line arguments for case when there is only one arg and it's a filename
-        if(len(argv) == 3 and argv[2].lower().endswith((".txt",".log"))):
+        if(len(sys.argv) == 3 and sys.argv[2].lower().endswith((".txt",".log"))):
             self.connectionType = "file"
             self.connectionName = argv[2]
         else:
-            allOptions = options
-            options += ['connectionType=', 'connectionName=', 'msg=','ip=','port=','msgdir=']
-            self.optlist, args = getopt.getopt(sys.argv[1:], '', allOptions)
             # connection modes
-            self.connectionType = "qtsocket"
-            self.connectionName = "127.0.0.1:5678"
             ip = ""
             port = ""
 
-            for opt in self.optlist:
-                if opt[0] == '--connectionType':
-                    self.connectionType = opt[1]
-                elif opt[0] == '--connectionName':
-                    self.connectionName = opt[1]
-                elif opt[0] == '--ip':
-                    ip = opt[1]
-                elif opt[0] == '--port':
-                    port = opt[1]
-                elif opt[0] == '--msg':
-                    option = opt[1].split('/')
-                    self.allowedMessages.append(option[0])
-                    if len(option) > 1:
-                        self.keyFields[option[0]] = option[1]
-                    print("only allowing msg " + str(option))
-                elif opt[0] == '--msgdir':
-                    msgLoadDir = opt[1]
+            if args.connectionType is not None:
+                self.connectionType = args.connectionType
+            if args.connectionName is not None:
+                self.connectionName = args.connectionName
+            if args.ip is not None:
+                ip = args.ip
+            if args.port is not None:
+                port = args.port
+            if args.msg is not None:
+                option = args.msg.split('/')
+                self.allowedMessages.append(option[0])
+                if len(option) > 1:
+                    self.keyFields[option[0]] = option[1]
+                print("only allowing msg " + str(option))
+            if args.msgdir:
+                msgLoadDir = args.msgdir
             
             # if either --ip or --port were used, override connectionName
-            if ip or port:
+            if args.ip is not None or args.port is not None:
                 self.connectionName = str(ip)+":"+str(port)
         
         # initialize the read function to None, so it's not accidentally called

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -38,7 +38,7 @@ class App(QtWidgets.QMainWindow):
                     This parameter is overridden by the --ip and --port options.''')
         parser.add_argument('--ip', help='The IP address for a socket connection.   Overrides connectionName.')
         parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
-#        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
+        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
         parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader. Overrides files.')
 
@@ -60,7 +60,8 @@ class App(QtWidgets.QMainWindow):
 
         # default to Network, unless we have a input filename that contains .txt
         headerName = "NetworkHeader"
-        if args.serial or (len(args.files) > 0 and any(".txt" in s for s in args.files) or any(".TXT" in s for s in args.files)):
+        if args.serial or (hasattr(args, 'files') and len(args.files) > 0 and 
+                (any(".txt" in s for s in args.files) or any(".TXT" in s for s in args.files))):
             headerName = "SerialHeader"
 
         self.name = name
@@ -92,12 +93,12 @@ class App(QtWidgets.QMainWindow):
             ip = args.ip
         if args.port is not None:
             port = args.port
-        # if args.msg is not None:
-        #     option = args.msg.split('/')
-        #     self.allowedMessages.append(option[0])
-        #     if len(option) > 1:
-        #         self.keyFields[option[0]] = option[1]
-        #     print("only allowing msg " + str(option))
+        if args.msg is not None:
+            option = args.msg.split('/')
+            self.allowedMessages.append(option[0])
+            if len(option) > 1:
+                self.keyFields[option[0]] = option[1]
+            print("only allowing msg " + str(option))
         if args.msgdir:
             msgLoadDir = args.msgdir
         

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -21,7 +21,7 @@ class App(QtWidgets.QMainWindow):
     connectionChanged = QtCore.pyqtSignal(bool)
 
     @classmethod
-    def addBaseArguments(cls, parser, skipFiles=False):
+    def addBaseArguments(cls, parser):
         '''
         Adds base app arguments to the provided ArgParser
         skipFiles - if True we won't provide an agument for a files list
@@ -39,10 +39,6 @@ class App(QtWidgets.QMainWindow):
         parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
         parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader.')
-
-        if skipFiles is False:
-            parser.add_argument('files', nargs=argparse.REMAINDER, help='''Zero or more files for processing.  
-                        Any file with a .txt extension will trigger the use of a SerialHeader instead of a NetworkHeader.''')
 
         return parser
     
@@ -62,11 +58,9 @@ class App(QtWidgets.QMainWindow):
         args.msg = None if hasattr(args, 'msg') == False else args.msg
         args.msgdir = None if hasattr(args, 'msgdir') == False else args.msgdir
 
-
         # default to Network, unless we have a input filename that contains .txt
         headerName = "NetworkHeader"
-        if args.serial or (hasattr(args, 'files') and len(args.files) > 0 and 
-                (any(".txt" in s for s in args.files) or any(".TXT" in s for s in args.files))):
+        if args.serial or (args.connectionType=='file' and os.path.splitext(args.connectionType)[1].lower() == '.txt'):
             headerName = "SerialHeader"
 
         self.name = name

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -308,10 +308,10 @@ class MsgCommandWidget(QtWidgets.QWidget):
     
 class Gui(App, QtWidgets.QMainWindow):
     @classmethod
-    def addBaseArguments(cls, parser, skipFiles=False):
+    def addBaseArguments(cls, parser):
         '''
         Adds base app arguments to the provided ArgParser
-        skipFiles - if True we won't provide an agument for a files list
+
         returns the parser
         '''
 
@@ -319,7 +319,7 @@ class Gui(App, QtWidgets.QMainWindow):
         # code using the Gui from including the App as a dependency.
         # It also allows us to inject Gui specific arguments into this
         # base class later.
-        return App.addBaseArguments(parser, skipFiles)
+        return App.addBaseArguments(parser)
 
     '''Gui base class that provides standard connection and status UI
 

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -308,12 +308,12 @@ class MsgCommandWidget(QtWidgets.QWidget):
     
 class Gui(App, QtWidgets.QMainWindow):
     @classmethod
-    def getArgParser(cls, parent=None):
+    def getArgParser(cls, parent=None, skipFiles=False, ):
         '''Helper delegate.  We wrap the App internal to the Gui class
         so rather than force users to include both Gui and App they can
         just invoke Gui.  Also allows us to inject our own ArgumentParser later
         if we want to add Gui specific command line args'''
-        return App.getArgParser(parent)
+        return App.getArgParser(parent, skipFiles)
 
     '''Gui base class that provides standard connection and status UI
 

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -308,12 +308,12 @@ class MsgCommandWidget(QtWidgets.QWidget):
     
 class Gui(App, QtWidgets.QMainWindow):
     @classmethod
-    def getArgParser(cls, parent=None, skipFiles=False):
+    def getArgParser(cls, description, epilog=None, parent=None, skipFiles=False):
         '''Helper delegate.  We wrap the App internal to the Gui class
         so rather than force users to include both Gui and App they can
         just invoke Gui.  Also allows us to inject our own ArgumentParser later
         if we want to add Gui specific command line args'''
-        return App.getArgParser(parent, skipFiles)
+        return App.getArgParser(description, epilog, parent, skipFiles)
 
     '''Gui base class that provides standard connection and status UI
 

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -1,6 +1,7 @@
 import sys
 import datetime
 import inspect
+import argparse
 
 from PyQt5 import QtGui, QtWidgets, QtCore, QtNetwork
 
@@ -306,14 +307,26 @@ class MsgCommandWidget(QtWidgets.QWidget):
         self.textBox.moveCursor (QtGui.QTextCursor.End)
     
 class Gui(App, QtWidgets.QMainWindow):
-    def __init__(self, name, argv, options, parent=None):
-        # default to Network, unless we have a input filename that contains .txt
-        headerName = "NetworkHeader"
-        if any(".txt" in s for s in argv) or any(".TXT" in s for s in argv):
-            headerName = "SerialHeader"
+    @classmethod
+    def getArgParser(cls, parent=None):
+        '''Helper delegate.  We wrap the App internal to the Gui class
+        so rather than force users to include both Gui and App they can
+        just invoke Gui.  Also allows us to inject our own ArgumentParser later
+        if we want to add Gui specific command line args'''
+        return App.getArgParser(parent)
+
+    '''Gui base class that provides standard connection and status UI
+
+        name - the name of the app - will be displayed in the title bar of the window
+        args - argparse.Namespace representing parsed arguments.  See app.py for
+               the standard options provided as part of this Gui/App framework used
+               in most MsgTools utilities.
+        parent - a parent Qt Widget to attach to
+    '''
+    def __init__(self, name, args, parent=None):
 
         QtWidgets.QMainWindow.__init__(self,parent)
-        App.__init__(self, name, headerName, argv, options)
+        App.__init__(self, name, args)
 
         # make a status bar to print status messages
         self.status = QtWidgets.QLabel("Initializing")

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -308,7 +308,7 @@ class MsgCommandWidget(QtWidgets.QWidget):
     
 class Gui(App, QtWidgets.QMainWindow):
     @classmethod
-    def getArgParser(cls, parent=None, skipFiles=False, ):
+    def getArgParser(cls, parent=None, skipFiles=False):
         '''Helper delegate.  We wrap the App internal to the Gui class
         so rather than force users to include both Gui and App they can
         just invoke Gui.  Also allows us to inject our own ArgumentParser later

--- a/msgtools/lib/gui.py
+++ b/msgtools/lib/gui.py
@@ -308,12 +308,18 @@ class MsgCommandWidget(QtWidgets.QWidget):
     
 class Gui(App, QtWidgets.QMainWindow):
     @classmethod
-    def getArgParser(cls, description, epilog=None, parent=None, skipFiles=False):
-        '''Helper delegate.  We wrap the App internal to the Gui class
-        so rather than force users to include both Gui and App they can
-        just invoke Gui.  Also allows us to inject our own ArgumentParser later
-        if we want to add Gui specific command line args'''
-        return App.getArgParser(description, epilog, parent, skipFiles)
+    def addBaseArguments(cls, parser, skipFiles=False):
+        '''
+        Adds base app arguments to the provided ArgParser
+        skipFiles - if True we won't provide an agument for a files list
+        returns the parser
+        '''
+
+        # Just delegate - this design choice is two fold - it prevents
+        # code using the Gui from including the App as a dependency.
+        # It also allows us to inject Gui specific arguments into this
+        # base class later.
+        return App.addBaseArguments(parser, skipFiles)
 
     '''Gui base class that provides standard connection and status UI
 

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -28,11 +28,11 @@ disables all socket options, and these will be ignored if specified.
 class Lumberjack(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
 
-        parser = argparse.ArgumentParser()
+        parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
         parser.add_argument('logfile', help='''The log file you want to split into CSV.  .log extension 
             assumes the log was created by MsgServer (binary).  A .txt extension assumes the file was
             created by SD logger.''')
-        parser=msgtools.lib.gui.Gui.getArgParser(DESCRIPTION, epilog=EPILOG, parent=parser)
+        parser=msgtools.lib.gui.Gui.addBaseArguments(parser)
         args = parser.parse_args()
 
         args.connectionType='file'

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -16,22 +16,14 @@ except ImportError:
 import msgtools.lib.gui
 
 DESCRIPTION='''
-Invoke like this
-    ./path/to/Lumberjack.py FILENAME
-    
-where FILENAME is the name of the log file you'd like to split into CSV.
-
-If the file extension is .log it will be assumed to be a log file created by MessageServer,
-if the file extension is .txt it will be assumed to be a log file created by the SparkFun serial SD logger.
 Lumberjack will create a directory named after the input file, and put multiple .csv files (one per message)
 in that directory.
 '''
 
 EPILOG='''
-This utility overrides the connectionName with the filename argument, and forces a "file" connectionType.  This 
-disables all socket options.
+This utility overrides connectionName with the logfile argument, and forces a "file" connectionType.  This 
+disables all socket options, and these will be ignored if specified.
 '''
-
 
 class Lumberjack(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -26,7 +26,7 @@ class Lumberjack(msgtools.lib.gui.Gui):
         parser.add_argument('logfile', help='''The log file you want to split into CSV.  .log extension 
             assumes the log was created by MsgServer (binary).  A .txt extension assumes the file was
             created by SD logger.''')
-        # parser=msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        # parser=msgtools.lib.gui.Gui.addBaseArguments(parser)
         args = parser.parse_args()
 
         args.connectionType='file'
@@ -35,7 +35,6 @@ class Lumberjack(msgtools.lib.gui.Gui):
             args.serial = True
         args.ip = None
         args.port = None
-        args.files = []
 
         msgtools.lib.gui.Gui.__init__(self, "Lumberjack 0.1", args, parent)
         

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -20,19 +20,19 @@ Lumberjack will create a directory named after the input file, and put multiple 
 in that directory.
 '''
 
-EPILOG='''
-This utility overrides connectionName with the logfile argument, and forces a "file" connectionType.  This 
-disables all socket options, and these will be ignored if specified.
-'''
+# EPILOG='''
+# This utility overrides connectionName with the logfile argument, and forces a "file" connectionType.  This 
+# disables all socket options, and these will be ignored if specified.
+# '''
 
 class Lumberjack(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
 
-        parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
+        parser = argparse.ArgumentParser(description=DESCRIPTION) #, epilog=EPILOG)
         parser.add_argument('logfile', help='''The log file you want to split into CSV.  .log extension 
             assumes the log was created by MsgServer (binary).  A .txt extension assumes the file was
             created by SD logger.''')
-        parser=msgtools.lib.gui.Gui.addBaseArguments(parser)
+        # parser=msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
         args = parser.parse_args()
 
         args.connectionType='file'

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -28,11 +28,11 @@ disables all socket options, and these will be ignored if specified.
 class Lumberjack(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
 
-        parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG)
+        parser = argparse.ArgumentParser()
         parser.add_argument('logfile', help='''The log file you want to split into CSV.  .log extension 
             assumes the log was created by MsgServer (binary).  A .txt extension assumes the file was
             created by SD logger.''')
-        parser=msgtools.lib.gui.Gui.getArgParser(parser)
+        parser=msgtools.lib.gui.Gui.getArgParser(DESCRIPTION, epilog=EPILOG, parent=parser)
         args = parser.parse_args()
 
         args.connectionType='file'

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -43,6 +43,13 @@ class Lumberjack(msgtools.lib.gui.Gui):
         args.port = None
         args.files = []
 
+        # Stuff base arguments in manually until we come back to verify
+        # all of the base arguments work with MsgLumberjack
+        args.lastserial = False
+        args.serial = None
+        args.msg = None
+        args.msgdir = None
+
         msgtools.lib.gui.Gui.__init__(self, "Lumberjack 0.1", args, parent)
         
         self.outputName = self.connectionName.replace('.log', '')

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -19,16 +19,10 @@ DESCRIPTION='''
 Lumberjack will create a directory named after the input file, and put multiple .csv files (one per message)
 in that directory.
 '''
-
-# EPILOG='''
-# This utility overrides connectionName with the logfile argument, and forces a "file" connectionType.  This 
-# disables all socket options, and these will be ignored if specified.
-# '''
-
 class Lumberjack(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
 
-        parser = argparse.ArgumentParser(description=DESCRIPTION) #, epilog=EPILOG)
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
         parser.add_argument('logfile', help='''The log file you want to split into CSV.  .log extension 
             assumes the log was created by MsgServer (binary).  A .txt extension assumes the file was
             created by SD logger.''')
@@ -42,13 +36,6 @@ class Lumberjack(msgtools.lib.gui.Gui):
         args.ip = None
         args.port = None
         args.files = []
-
-        # Stuff base arguments in manually until we come back to verify
-        # all of the base arguments work with MsgLumberjack
-        args.lastserial = False
-        args.serial = None
-        args.msg = None
-        args.msgdir = None
 
         msgtools.lib.gui.Gui.__init__(self, "Lumberjack 0.1", args, parent)
         

--- a/msgtools/lumberjack/lumberjack.py
+++ b/msgtools/lumberjack/lumberjack.py
@@ -39,6 +39,9 @@ class Lumberjack(msgtools.lib.gui.Gui):
         args.connectionName = args.logfile
         if args.logfile.lower().endswith('.txt'):
             args.serial = True
+        args.ip = None
+        args.port = None
+        args.files = []
 
         msgtools.lib.gui.Gui.__init__(self, "Lumberjack 0.1", args, parent)
         

--- a/msgtools/multilog/multilog.py
+++ b/msgtools/multilog/multilog.py
@@ -6,6 +6,7 @@
 #         text gets inserted in log whenever you hit enter in annotation box or click 'note' button next to annotate box.
 
 import sys
+import argparse
 from PyQt5 import QtCore, QtGui, QtWidgets
 from time import strftime
 
@@ -30,31 +31,52 @@ except RuntimeError as e:
     print("Error loading plot interface ["+str(e)+"]")
     print("Perhaps you need to install the PyQt5 version of pyqtgraph.")
 
+DESCRIPTION='''
+    MultiLog presents a UI that lets you control logging of messages on an 
+    individual basis, and send and receive messages pressing a button 
+    starts/stops a log file.  Underscores in label or field are replaced 
+    with spaces for display (to make entering command-line args easier)
+
+    Log filenames will be composed like so:
+        YEAR_MONTH_DAY.TEXT1.TEXT2.TAG1.log'''
+
+EPILOG='''
+    Example usage: multilog --fields LABEL1 LABEL2 --buttons hotkey:X,tag:TAG1,label:LABEL3  
+    hotkey:X,tag:TAG2,label:LABEL4 --show MSGNAME MSGNAME2 --plot MSGNAME[fieldname1,fieldname2] 
+    MSGNAME2[fieldname3,fieldname4] --send MSGNAME MSGNAME2
+    '''
+
 def removePrefix(text, prefix):
     return text[len(prefix):] if text.startswith(prefix) else text
     
 class Multilog(msgtools.lib.gui.Gui):
     def __init__(self, argv, parent=None):
-        if(len(argv) < 2):
-            exit('''
-Invoke like this
-    ./path/to/Multilog.py --field=LABEL1 --field=LABEL2 --button=hotkey:X,tag:TAG1,label:LABEL3  --button=hotkey:X,tag:TAG2,label:LABEL4 --show=MSGNAME --plot=MSGNAME[fieldname1,fieldname2] --send=MSGNAME
-    
-each --field adds a text field named the specified LABEL, and the value of the text field will become part of the filename.
-each --button adds a pushbutton named for the specified LABEL, with a hotkey of the specified key, and the tag value will become part of the filename
-each --show adds a table view of that MSGNAME
-each --plot adds a plot of the fields within MSGNAME.  If fields left off, all fields are plotted
-each --send adds a tree view to edit a message with a 'send' button to send it
+        parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG,
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument('--fields', nargs='+', default=[], 
+            help='''each --field argument adds a text field named the specified LABEL, and 
+                    the value of the text field will become part of the filename.  
+                    Example argument: LABEL1''')
+        parser.add_argument('--buttons', nargs='+', default=[], help='''each --button 
+                    argument adds a pushbutton named for the specified LABEL, with a 
+                    hotkey of the specified key, and the tag value will become part of 
+                    the filename.  Example argument: hotkey:X,tag:TAG1,label:LABEL1''')
+        parser.add_argument('--show', nargs='+', default=[], 
+            help='each --show argument adds a table view of that MSGNAME')
+        parser.add_argument('--plot', nargs='+', default=[], help='''each --plot argument 
+                    adds a plot of the fields within MSGNAME.  If fields left off, all 
+                    fields are plotted.  Example argument: MSGNAME[fieldname1,fieldname2]''')
+        parser.add_argument('--send', nargs='+', default=[], help='''each --send argument 
+                    is a message name that adds a tree view to edit a message with a 'send' 
+                    button to send it.  Example argument: MSGNAME''')
 
-pressing a button starts/stops a log file
-underscores in label or field are replaced with spaces for display (to make entering command-line args easier)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
 
-filenames will be composed like so:
-    YEAR_MONTH_DAY.TEXT1.TEXT2.TAG1.log
-''')
+        args=parser.parse_args()
 
-        options = ['field=', 'button=', 'show=', 'plot=', 'send=']
-        msgtools.lib.gui.Gui.__init__(self, "Multilog 0.1", argv, options, parent)
+        print(args)
+
+        msgtools.lib.gui.Gui.__init__(self, "Multilog 0.1", args, parent)
         
         # event-based way of getting messages
         self.RxMsg.connect(self.ProcessMessage)
@@ -84,90 +106,88 @@ filenames will be composed like so:
         self.buttons = []
         self.activeLogButton = None
         txMsgs = None
-        for option in self.optlist:
-            if option[0] == '--field':
-                label = option[1].replace("_"," ")
 
-                # add text field
-                lvLayout.addWidget(QtWidgets.QLabel(label))
-                lineEdit = QtWidgets.QLineEdit()
-                rvLayout.addWidget(lineEdit)
-                self.lineEdits.append(lineEdit)
-            elif option[0] == '--button':
-                arg = option[1]
-                parts = arg.split(",")
-                options = {}
-                for option in parts:
-                    key, value = option.split(":")
-                    options[key] = value
+        # Process command line args
+        for field in args.fields:
+            label = field.replace("_"," ")
 
-                # add button
-                label = options["label"].replace("_"," ")
-                button = QtWidgets.QPushButton(label)
-                # how to set hot key?  do it at window level, or at button level?  or something else?
-                #button.hotKey = options["hotkey"]
-                button.label = label
-                self.buttons.append(button)
-                if "tag" in options:
-                    button.tag = options["tag"]
-                else:
-                    button.tag = None
-                vLayout.addWidget(button)
-                
-                button.clicked.connect(self.HandleButtonPress)
-            elif option[0] == '--show':
-                msgname = option[1]
+            # add text field
+            lvLayout.addWidget(QtWidgets.QLabel(label))
+            lineEdit = QtWidgets.QLineEdit()
+            rvLayout.addWidget(lineEdit)
+            self.lineEdits.append(lineEdit)
+        for button in args.buttons:
+            parts = button.split(",")
+            options = {}
+            for option in parts:
+                key, value = option.split(":")
+                options[key] = value
+
+            # add button
+            label = options["label"].replace("_"," ")
+            button = QtWidgets.QPushButton(label)
+            # how to set hot key?  do it at window level, or at button level?  or something else?
+            #button.hotKey = options["hotkey"]
+            button.label = label
+            self.buttons.append(button)
+            if "tag" in options:
+                button.tag = options["tag"]
+            else:
+                button.tag = None
+            vLayout.addWidget(button)
+            
+            button.clicked.connect(self.HandleButtonPress)
+        for msgname in args.show:
+            subWidget = QtWidgets.QWidget()
+            subLayout = QtWidgets.QVBoxLayout()
+            subWidget.setLayout(subLayout)
+            splitter.addWidget(subWidget)
+            subLayout.addWidget(QtWidgets.QLabel(msgname))
+            msgClass = self.msgLib.MsgClassFromName[msgname]
+            msgWidget = msgtools.lib.gui.MsgTreeWidget(msgClass, None, 1, 1)
+            subLayout.addWidget(msgWidget)
+            if not msgClass.ID in self.msgHandlers:
+                self.msgHandlers[msgClass.ID] = []
+            self.msgHandlers[msgClass.ID].append(msgWidget)
+        for plotarg in args.plot:
+            if plottingLoaded:
+                msgname = plotarg.split("[")[0]
+                try:
+                    fieldNames = plotarg.split("[")[1].replace("]","").split(',')
+                except IndexError:
+                    fieldNames = []
                 subWidget = QtWidgets.QWidget()
                 subLayout = QtWidgets.QVBoxLayout()
                 subWidget.setLayout(subLayout)
                 splitter.addWidget(subWidget)
                 subLayout.addWidget(QtWidgets.QLabel(msgname))
                 msgClass = self.msgLib.MsgClassFromName[msgname]
-                msgWidget = msgtools.lib.gui.MsgTreeWidget(msgClass, None, 1, 1)
+                # should plot only fields specified, if user specified fields
+                firstTime = True
+                for fieldInfo in msgClass.fields:
+                    if fieldInfo.name in fieldNames or not fieldNames:
+                        if firstTime:
+                            msgWidget = MsgPlot(msgClass, fieldInfo, 0) # non-zero for subsequent elements of arrays!
+                            firstTime = False
+                        else:
+                            msgWidget.addPlot(msgClass, fieldInfo, 0) # non-zero for subsequent elements of arrays!
                 subLayout.addWidget(msgWidget)
                 if not msgClass.ID in self.msgHandlers:
                     self.msgHandlers[msgClass.ID] = []
                 self.msgHandlers[msgClass.ID].append(msgWidget)
-            elif option[0] == '--plot':
-                if plottingLoaded:
-                    msgname = option[1].split("[")[0]
-                    try:
-                        fieldNames = option[1].split("[")[1].replace("]","").split(',')
-                    except IndexError:
-                        fieldNames = []
-                    subWidget = QtWidgets.QWidget()
-                    subLayout = QtWidgets.QVBoxLayout()
-                    subWidget.setLayout(subLayout)
-                    splitter.addWidget(subWidget)
-                    subLayout.addWidget(QtWidgets.QLabel(msgname))
-                    msgClass = self.msgLib.MsgClassFromName[msgname]
-                    # should plot only fields specified, if user specified fields
-                    firstTime = True
-                    for fieldInfo in msgClass.fields:
-                        if fieldInfo.name in fieldNames or not fieldNames:
-                            if firstTime:
-                                msgWidget = MsgPlot(msgClass, fieldInfo, 0) # non-zero for subsequent elements of arrays!
-                                firstTime = False
-                            else:
-                                msgWidget.addPlot(msgClass, fieldInfo, 0) # non-zero for subsequent elements of arrays!
-                    subLayout.addWidget(msgWidget)
-                    if not msgClass.ID in self.msgHandlers:
-                        self.msgHandlers[msgClass.ID] = []
-                    self.msgHandlers[msgClass.ID].append(msgWidget)
-            elif option[0] == '--send':
-                msgname = option[1]
-                msgClass = self.msgLib.MsgClassFromName[msgname]
-                if not txMsgs:
-                    txMsgs = QtWidgets.QTreeWidget(parent)
-                    txMsgs.setColumnCount(4)
-                    txMsgsHeader = QtWidgets.QTreeWidgetItem(None, ["Message", "Field", "Value", "Units", "Description"])
-                    txMsgs.setHeaderItem(txMsgsHeader)
-                    splitter.addWidget(txMsgs)
-                
-                msg = msgClass()
-                # set fields to defaults
-                msgWidget = msgtools.lib.txtreewidget.EditableMessageItem(txMsgs, msg)
-                msgWidget.qobjectProxy.send_message.connect(self.on_tx_message_send)
+        for msgname in args.send:
+            msgClass = self.msgLib.MsgClassFromName[msgname]
+            if not txMsgs:
+                txMsgs = QtWidgets.QTreeWidget(parent)
+                txMsgs.setColumnCount(4)
+                txMsgsHeader = QtWidgets.QTreeWidgetItem(None, ["Message", "Field", "Value", "Units", "Description"])
+                txMsgs.setHeaderItem(txMsgsHeader)
+                splitter.addWidget(txMsgs)
+            
+            msg = msgClass()
+            # set fields to defaults
+            msgWidget = msgtools.lib.txtreewidget.EditableMessageItem(txMsgs, msg)
+            msgWidget.qobjectProxy.send_message.connect(self.on_tx_message_send)
 
 
         # create a new file

--- a/msgtools/multilog/multilog.py
+++ b/msgtools/multilog/multilog.py
@@ -70,7 +70,7 @@ class Multilog(msgtools.lib.gui.Gui):
                     is a message name that adds a tree view to edit a message with a 'send' 
                     button to send it.  Example argument: MSGNAME''')
 
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
 
         args=parser.parse_args()
 

--- a/msgtools/noisemaker/bandwidthtestecho.py
+++ b/msgtools/noisemaker/bandwidthtestecho.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import argparse
 from PyQt5 import QtGui, QtWidgets, QtCore
 
 try:
@@ -11,9 +12,20 @@ except ImportError:
     from msgtools.lib.messaging import Messaging
 import msgtools.lib.gui
 
+DESCRIPTION='''
+    Connects to a MsgSever and listens for BandwidthTest messages. When a message is received
+    it is timestamped and sent back.  This app is meant to be used with the BandwidthTester app 
+    which sources the BandwidthTest messages and displays results.  The UI also lets you adjust
+    % of received messages that are simply dropped.
+    '''
+
 class BandwidthTestEcho(msgtools.lib.gui.Gui):
-    def __init__(self, argv, parent=None):
-        msgtools.lib.gui.Gui.__init__(self, "Bandwidth Test Echo 0.1", argv, [], parent)
+    def __init__(self, parent=None):
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        args = parser.parse_args()
+
+        msgtools.lib.gui.Gui.__init__(self, "Bandwidth Test Echo 0.1", args, parent)
         
         self.msgCount = 0
         self.dropPercent = 0
@@ -73,7 +85,7 @@ class BandwidthTestEcho(msgtools.lib.gui.Gui):
 
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
-    msgApp = BandwidthTestEcho(sys.argv)
+    msgApp = BandwidthTestEcho()
     msgApp.show()
     sys.exit(app.exec_())
 

--- a/msgtools/noisemaker/bandwidthtestecho.py
+++ b/msgtools/noisemaker/bandwidthtestecho.py
@@ -22,7 +22,7 @@ DESCRIPTION='''
 class BandwidthTestEcho(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
         args = parser.parse_args()
 
         msgtools.lib.gui.Gui.__init__(self, "Bandwidth Test Echo 0.1", args, parent)

--- a/msgtools/noisemaker/bandwidthtester.py
+++ b/msgtools/noisemaker/bandwidthtester.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import argparse
 from PyQt5 import QtGui, QtWidgets, QtCore
 import time
 
@@ -12,10 +13,22 @@ except ImportError:
     from msgtools.lib.messaging import Messaging
 import msgtools.lib.gui
 
+DESCRIPTION='''
+    BandwidthTester is designed to work with the BandWidthTestEcho utility.  It connects to a
+    MsgServer and sends Bandwidth test messages, listening for echo responses with timestamps.
+    Basic stats are provided to allow you rough order of throughput.  Python is not very stable
+    when it comes to timing and multi-threaded operations so expect some margin of error in your 
+    results.
+'''
+
 class BandwidthTester(msgtools.lib.gui.Gui):
     startTime = int(time.time() * 1000)
-    def __init__(self, argv, parent=None):
-        msgtools.lib.gui.Gui.__init__(self, "Bandwidth Tester 0.1", argv, [], parent)
+    def __init__(self, parent=None):
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        args = parser.parse_args()
+
+        msgtools.lib.gui.Gui.__init__(self, "Bandwidth Tester 0.1", args, parent)
         
         self.lastTxSequence = 0
         self.lastRxSequence = 0
@@ -201,7 +214,7 @@ class BandwidthTester(msgtools.lib.gui.Gui):
 
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
-    msgApp = BandwidthTester(sys.argv)
+    msgApp = BandwidthTester()
     msgApp.show()
     sys.exit(app.exec_())
 

--- a/msgtools/noisemaker/bandwidthtester.py
+++ b/msgtools/noisemaker/bandwidthtester.py
@@ -25,7 +25,7 @@ class BandwidthTester(msgtools.lib.gui.Gui):
     startTime = int(time.time() * 1000)
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
         args = parser.parse_args()
 
         msgtools.lib.gui.Gui.__init__(self, "Bandwidth Tester 0.1", args, parent)

--- a/msgtools/noisemaker/noisemaker.py
+++ b/msgtools/noisemaker/noisemaker.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 import sys
+import argparse
 from datetime import datetime
 from PyQt5 import QtGui, QtWidgets
 from PyQt5.QtCore import QTimer
@@ -13,10 +14,26 @@ except ImportError:
     from msgtools.lib.messaging import Messaging
 import msgtools.lib.gui
 
+DESCRIPTION='''
+    Noisemaker is a utility for generating message traffic.  Messages are roughly 
+    staggered with a constant delta between each message, triggered at a rate 33Hz rate.
+    Python's built in timing is highly unstable.  Timing won't be extremeley precise.
+'''
+
 class NoiseMaker(msgtools.lib.gui.Gui):
-    def __init__(self, argv, parent=None):
-        options = ['msgs=']
-        msgtools.lib.gui.Gui.__init__(self, "Noise Maker 0.1", argv, options, parent)
+    def __init__(self, parent=None):
+
+        parser = argparse.ArgumentParser(description=DESCRIPTION)
+        parser.add_argument('msgs', nargs='*', help='''
+            One or more messages that you wish to send.  This entire list is sent each 
+            time the message period is up.  Network messages are ignored.  By default we 
+            send all known messages.''')
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        args = parser.parse_args()
+
+        print(args)
+
+        msgtools.lib.gui.Gui.__init__(self, "Noise Maker 0.1", args, parent)
         
         self.timeInfo = Messaging.findFieldInfo(Messaging.hdr.fields, "Time")
         
@@ -35,10 +52,7 @@ class NoiseMaker(msgtools.lib.gui.Gui):
         self.setCentralWidget(self.startStop)
         
         # check if user specified which messages we should output
-        msgs = None
-        for option in self.optlist:
-            if option[0] == '--msgs':
-                msgs = option[1]
+        msgs = args.msgs
         
         # find a few messages to send at specified rates
         period = 0.3
@@ -47,13 +61,13 @@ class NoiseMaker(msgtools.lib.gui.Gui):
         self.msgTxTime = {}
         for msgName in Messaging.MsgClassFromName:
             if not msgName.startswith("Network"):
-                if msgs and not msgs in msgName:
+                if len(msgs) > 0 and msgName not in msgs:
                     continue
-                #print("found message " + msgName)
+                print("found message " + msgName)
                 self.msgPeriod[msgName] = period
                 period = period + 0.020
                 self.msgTxTime[msgName] = 0
-        
+       
         self.msgTimer.start()
         
     def startStopFn(self):
@@ -122,7 +136,7 @@ class NoiseMaker(msgtools.lib.gui.Gui):
 
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
-    msgApp = NoiseMaker(sys.argv)
+    msgApp = NoiseMaker()
     msgApp.show()
     sys.exit(app.exec_())
 

--- a/msgtools/noisemaker/noisemaker.py
+++ b/msgtools/noisemaker/noisemaker.py
@@ -28,7 +28,7 @@ class NoiseMaker(msgtools.lib.gui.Gui):
             One or more messages that you wish to send.  This entire list is sent each 
             time the message period is up.  Network messages are ignored.  By default we 
             send all known messages.''')
-        parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+        parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
         args = parser.parse_args()
 
         print(args)

--- a/msgtools/scope/scope.py
+++ b/msgtools/scope/scope.py
@@ -408,7 +408,7 @@ class MessageScopeGui(msgtools.lib.gui.Gui):
 
 def main():
     # Setup a command line processor...
-    parser = msgtools.lib.gui.Gui.getArgParser(argparse.ArgumentParser(description=DESCRIPTION))
+    parser = msgtools.lib.gui.Gui.getArgParser(argparse.ArgumentParser(description=DESCRIPTION), True)
     args = parser.parse_args()
 
     app = QApplication(sys.argv)

--- a/msgtools/scope/scope.py
+++ b/msgtools/scope/scope.py
@@ -409,7 +409,7 @@ class MessageScopeGui(msgtools.lib.gui.Gui):
 def main():
     # Setup a command line processor...
     parser = argparse.ArgumentParser(description=DESCRIPTION)
-    parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
+    parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
     args = parser.parse_args()
 
     app = QApplication(sys.argv)

--- a/msgtools/scope/scope.py
+++ b/msgtools/scope/scope.py
@@ -408,7 +408,8 @@ class MessageScopeGui(msgtools.lib.gui.Gui):
 
 def main():
     # Setup a command line processor...
-    parser = msgtools.lib.gui.Gui.getArgParser(argparse.ArgumentParser(description=DESCRIPTION), True)
+    parser = argparse.ArgumentParser(description=DESCRIPTION)
+    parser = msgtools.lib.gui.Gui.addBaseArguments(parser, skipFiles=True)
     args = parser.parse_args()
 
     app = QApplication(sys.argv)

--- a/msgtools/scope/scope.py
+++ b/msgtools/scope/scope.py
@@ -5,6 +5,7 @@ from datetime import datetime
 import collections
 import functools
 import threading
+import argparse
 
 from PyQt5.QtGui import *
 from PyQt5.QtWidgets import *
@@ -31,6 +32,9 @@ except RuntimeError as e:
     print("Error loading plot interface ["+str(e)+"]")
     print("Perhaps you need to install the PyQt5 version of pyqtgraph.")
     
+DESCRIPTION='''MsgScope provides a graphical interface that allow syou to view, plot, and send
+    messages.  It requires defined messages in Python.  A list of discovered messages will be
+    displayed in the upper left of the UI.'''
 
 class RxRateCalculatorThread(QObject):
     rates_updated = pyqtSignal(object)
@@ -100,8 +104,8 @@ class ClosableDockWidget(QDockWidget):
         self.parent().removeDockWidget(self)
 
 class MessageScopeGui(msgtools.lib.gui.Gui):
-    def __init__(self, argv, parent=None):
-        msgtools.lib.gui.Gui.__init__(self, "Message Scope 0.1", argv, [], parent)
+    def __init__(self, args, parent=None):
+        msgtools.lib.gui.Gui.__init__(self, "Message Scope 0.1", args, parent)
 
         # event-based way of getting messages
         self.RxMsg.connect(self.ProcessMessage)
@@ -402,9 +406,13 @@ class MessageScopeGui(msgtools.lib.gui.Gui):
     def clear_tx(self):
         self.txMsgs.clear()
 
-def main(args=None):
+def main():
+    # Setup a command line processor...
+    parser = msgtools.lib.gui.Gui.getArgParser(argparse.ArgumentParser(description=DESCRIPTION))
+    args = parser.parse_args()
+
     app = QApplication(sys.argv)
-    msgScopeGui = MessageScopeGui(sys.argv)
+    msgScopeGui = MessageScopeGui(args)
     msgScopeGui.show()
     sys.exit(app.exec_())
 

--- a/msgtools/server/server.py
+++ b/msgtools/server/server.py
@@ -29,6 +29,11 @@ DESCRIPTION='''
 
 EPILOG='''
 
+Headers
+=======
+MsgServer expects headers.NetworkHeader as the prequel for all messages.  
+All clients need to send and receive messages with a NetworkHeader.
+
 TCP and Websockets
 ==================
 MsgServer always runs a TCP and Websocket server.  The Websocket server

--- a/msgtools/server/server.py
+++ b/msgtools/server/server.py
@@ -162,7 +162,7 @@ class MessageServer(QtWidgets.QMainWindow):
             tcpport = args.port
             wsport = tcpport+1
         
-        if args.lastserial is not None or args.serial is not None:
+        if args.lastserial is not False or args.serial is not None:
             from SerialHeader import SerialHeader
             from msgtools.server.SerialPlugin import SerialConnection
             serialPortName = args.serial if args.serial is not None else None

--- a/msgtools/server/server.py
+++ b/msgtools/server/server.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import sys
-import getopt
+import argparse
 
 try:
     from msgtools.lib.messaging import Messaging
@@ -15,39 +15,132 @@ from PyQt5 import QtCore, QtGui, QtWidgets, QtNetwork
 from msgtools.server.TcpServer import *
 from msgtools.server.WebSocketServer import *
 
+DESCRIPTION='''
+    MsgServer acts as a central routing hub for one or more message clients.
+    Messages received, are reflected onto all other client connections.
+    Bluetooth (RFCOMM), TCP, Websocket, and USB Serial clients are all
+    supported.  
+
+    MsgServer also provides binary logging capability from from both the UI
+    and Network.xLogx messages.  Message masks and subscription are also
+    supported through subscription messages defined in the Network 
+    group.
+'''
+
+EPILOG='''
+
+TCP and Websockets
+==================
+MsgServer always runs a TCP and Websocket server.  The Websocket server
+port is always one greater than the TCP port.  The default ports are
+5678 and 5679 for TCP and Websockets respectively.
+
+SPP and RFCOMM
+==============
+SPP ("Serial Port Profile") is a Bluetooth service profile for emulating 
+an RS232 serial connection over Bluetooth. To accomplish this, SPP uses an 
+RFCOMM (a reliable stream-oriented connection; the TCP of the Bluetooth 
+world) socket to move the data.  SPP provides RS-232 signaling concepts
+for CTS, RTS, etc.
+
+BluetoothRFCOMMQt
+=================
+* Requires Qt
+* Works on Mac and Linux.
+
+BluetoothRFCOMM
+===============
+* Requires PyBlueZ which may not be available for Python versions after 3.5
+* Works on Windows and Linux
+
+Bluetooth Arguments
+===================
+Both command line options take a Bluetooth MAC address, and optionally 
+an RFCOMM port to connect to. For instance: 
+
+    --bluetoothRFCOMM=00:de:ad:be:ef:77,8
+
+If you omit the port (",8", above), then the code will attempt to use 
+Bluetooth SDP to find an SPP service on the target device; if multiple 
+services are available, an arbitrary one will be chosen.
+
+Bluetooth Troubleshooting
+=========================
+If you can't connect to your device, try pairing it with your PC first.
+Sometimes devices require pairing before allowing an arbitrary connection.
+
+Examples
+========
+    msgserver &
+
+    Will run MsgServer on the default TCP Websocket ports 5678 and 5679.
+
+    msgserver --serial
+
+    Will run MsgServer with a serial port input on the last used port, 
+    and TCP/Websocket on 5678, and 5679 respectively.
+
+    msgserver --serial= /dev/tty12
+
+    Will run MsgServer with a serial port connected on /dev/tty12. and
+    a TCP/Websocket port on 5678, and 5679 respectively.
+
+    msgserver --port 1234
+
+    Will run MsgServer with a TCP port on 1234 and Websocket port on 1235
+
+    msgserver --bluetoothRFCOMM=00:de:ad:be:ef:77
+
+    Will run MsgServer on the default TCP/Websocket ports and attempt to connect
+    to the indicated Bluetooth MAC.  SDP will be used to try and discover
+    the appropriate channel.
+
+
+    msgserver --bluetoothRFCOMM=00:de:ad:be:ef:77,8
+
+    Will run MsgServer on the default TCP/Websocket ports and attempt to connect
+    to the indicated Bluetooth MAC and channel 8.
+
+'''
+
 class MessageServer(QtWidgets.QMainWindow):
-    def __init__(self, argv):
+    def __init__(self):
         QtWidgets.QMainWindow.__init__(self)
         
         self.settings = QtCore.QSettings("MsgTools", "MessageServer")
         self.logFile = None
         self.logFileType = None
+
+        parser = argparse.ArgumentParser(description=DESCRIPTION, epilog=EPILOG, 
+            formatter_class=argparse.RawDescriptionHelpFormatter)
+        parser.add_argument('--serial', dest='lastserial', action='store_true', 
+            help='Use a serial port input on the last used port' )
+        parser.add_argument('--serial=', dest='serial', 
+            help='''Use a serial port input with the specified serial port name.  This
+                    form takes precedence over --serial if both are specified.''' )
+        parser.add_argument('--bluetoothSPP', 
+            help='Use a Bluetooth SPP connection to the indicated port.  See below for details.')
+        parser.add_argument('--bluetoothRFCOMM', 
+            help='Use a Bluetooth RFCOMM connection to the indicated port.  See below for details.')
+        parser.add_argument('--bluetoothRFCOMMQt', 
+            help='Use a QT Bluetooth RFCOMM connection on the indicated port. See below for details.')
+        parser.add_argument('--plugin', help='Specify a plugin module to use')
+        parser.add_argument('--msgdir', 
+            help='''Specify the directory for generated python code to use for headers, and other 
+                    message definitions''')
+        parser.add_argument('--port', type=int, 
+            help='The TCP port to use.  Websockets are always TCP port + 1.')
+
+        args = parser.parse_args()
         
-        # directory to load messages from.
-        msgLoadDir = None
-        # need a way to make serial= and serial both work!
         try:
-            options = ['serial=', 'bluetoothSPP=', 'bluetoothRFCOMM=', 'bluetoothRFCOMMQt=', 'plugin=', 'port=', 'msgdir=']
-            self.optlist, args = getopt.getopt(sys.argv[1:], '', options)
-        except getopt.GetoptError:
-            pass
-
-        try:
-            options = ['serial', 'bluetoothSPP=', 'bluetoothRFCOMM=', 'bluetoothRFCOMMQt=', 'plugin=', 'port=', 'msgdir=']
-            self.optlist, args = getopt.getopt(sys.argv[1:], '', options)
-        except getopt.GetoptError:
-            pass
-
-        for opt in self.optlist:
-            if opt[0] == '--msgdir':
-                msgLoadDir = opt[1]
-        try:
-            self.msgLib = Messaging(msgLoadDir, False, "NetworkHeader")
+            self.msgLib = Messaging(args.msgdir, False, "NetworkHeader")
         except ImportError:
             print("\nERROR! Auto-generated python code not found!")
             print("cd to a directory downstream from a parent of obj/CodeGenerator/Python")
             print("or specify that directory with --msgdir=PATH\n")
             quit()
+
         self.networkMsgs = self.msgLib.Messages.Network
 
         self.clients = {}
@@ -60,63 +153,67 @@ class MessageServer(QtWidgets.QMainWindow):
         tcpport = 5678
         wsport = 5679
 
-        for opt in self.optlist:
-            if opt[0] == '--port':
-                tcpport = int(opt[1])
-                wsport = tcpport+1
-            elif opt[0] == '--serial':
-                from SerialHeader import SerialHeader
-                from msgtools.server.SerialPlugin import SerialConnection
-                serialPortName = opt[1]
-                self.serialPort = SerialConnection(SerialHeader, serialPortName)
-                self.serialPort.statusUpdate.connect(self.onStatusUpdate)
-                self.onNewConnection(self.serialPort)
-                self.serialPort.start()
-            elif opt[0] == '--bluetoothSPP':
-                from BluetoothHeader import BluetoothHeader
-                from msgtools.server.SerialPlugin import SerialConnection
-                bluetoothPortName = opt[1]
-                self.bluetoothPort = SerialConnection(BluetoothHeader, bluetoothPortName)
-                self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
-                self.onNewConnection(self.bluetoothPort)
-                self.bluetoothPort.start()
-            elif opt[0] == '--bluetoothRFCOMM':
-                from msgtools.server.BluetoothRFCOMM import BluetoothRFCOMMConnection
-                btArgs = opt[1].split(",")
-                if len(btArgs)>1:
-                    btArgs[1] = int(btArgs[1])
-                self.bluetoothPort = BluetoothRFCOMMConnection(*btArgs)
-                self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
-                self.onNewConnection(self.bluetoothPort)
-            elif opt[0] == '--bluetoothRFCOMMQt':
-                from msgtools.server.BluetoothRFCOMMQt import BluetoothRFCOMMQtConnection
-                from PyQt5 import QtBluetooth
-                btArgs = opt[1].split(",")
-                btHost = btArgs[0]
-                if len(btArgs)>1:
-                    btPort = int(btArgs[1])
-                else:
-                    btPort = 8
-                self.btSocket = QtBluetooth.QBluetoothSocket(QtBluetooth.QBluetoothServiceInfo.RfcommProtocol)
-                self.btSocket.connectToService(QtBluetooth.QBluetoothAddress(btHost), btPort)
-                self.bluetoothPort = BluetoothRFCOMMQtConnection(self.btSocket)
-                self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
-                self.onNewConnection(self.bluetoothPort)
-            elif opt[0] == '--plugin':
-                filename = opt[1]
-                import os
-                moduleName = os.path.splitext(os.path.basename(filename))[0]
-                if Messaging.debug:
-                    print("loading module ", filename, "as",moduleName)
+        if args.port is not None:
+            tcpport = args.port
+            wsport = tcpport+1
+        
+        if args.lastserial is not None or args.serial is not None:
+            from SerialHeader import SerialHeader
+            from msgtools.server.SerialPlugin import SerialConnection
+            serialPortName = args.serial if args.serial is not None else None
+            self.serialPort = SerialConnection(SerialHeader, serialPortName)
+            self.serialPort.statusUpdate.connect(self.onStatusUpdate)
+            self.onNewConnection(self.serialPort)
+            self.serialPort.start()
+        
+        if args.bluetoothSPP is not None:
+            from BluetoothHeader import BluetoothHeader
+            from msgtools.server.SerialPlugin import SerialConnection
+            bluetoothPortName = args.bluetoothSPP
+            self.bluetoothPort = SerialConnection(BluetoothHeader, bluetoothPortName)
+            self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
+            self.onNewConnection(self.bluetoothPort)
+            self.bluetoothPort.start()
 
-                name = filename.replace("/", "_")
-                import importlib
-                self.plugin = importlib.machinery.SourceFileLoader(name, filename).load_module(name)
+        if args.bluetoothRFCOMM is not None:
+            from msgtools.server.BluetoothRFCOMM import BluetoothRFCOMMConnection
+            btArgs = args.bluetoothRFCOMM.split(",")
+            if len(btArgs)>1:
+                btArgs[1] = int(btArgs[1])
+            self.bluetoothPort = BluetoothRFCOMMConnection(*btArgs)
+            self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
+            self.onNewConnection(self.bluetoothPort)
+        
+        if args.bluetoothRFCOMMQt is not None:
+            from msgtools.server.BluetoothRFCOMMQt import BluetoothRFCOMMQtConnection
+            from PyQt5 import QtBluetooth
+            btArgs = args.bluetoothRFCOMMQt.split(",")
+            btHost = btArgs[0]
+            if len(btArgs)>1:
+                btPort = int(btArgs[1])
+            else:
+                btPort = 8
+            self.btSocket = QtBluetooth.QBluetoothSocket(QtBluetooth.QBluetoothServiceInfo.RfcommProtocol)
+            self.btSocket.connectToService(QtBluetooth.QBluetoothAddress(btHost), btPort)
+            self.bluetoothPort = BluetoothRFCOMMQtConnection(self.btSocket)
+            self.bluetoothPort.statusUpdate.connect(self.onStatusUpdate)
+            self.onNewConnection(self.bluetoothPort)
+        
+        if args.plugin is not None:
+            filename = args.plugin
+            import os
+            moduleName = os.path.splitext(os.path.basename(filename))[0]
+            if Messaging.debug:
+                print("loading module ", filename, "as",moduleName)
 
-                self.pluginPort = self.plugin.PluginConnection()
-                self.pluginPort.statusUpdate.connect(self.onStatusUpdate)
-                self.pluginPort.newConnection.connect(self.onNewConnection)
-                self.pluginPort.start()
+            name = filename.replace("/", "_")
+            import importlib
+            self.plugin = importlib.machinery.SourceFileLoader(name, filename).load_module(name)
+
+            self.pluginPort = self.plugin.PluginConnection()
+            self.pluginPort.statusUpdate.connect(self.onStatusUpdate)
+            self.pluginPort.newConnection.connect(self.onNewConnection)
+            self.pluginPort.start()
 
         self.tcpServer = TcpServer(tcpport)
         self.tcpServer.statusUpdate.connect(self.onStatusUpdate)
@@ -309,7 +406,7 @@ class MessageServer(QtWidgets.QMainWindow):
 def main(args=None):
     app = QtWidgets.QApplication(sys.argv)
 
-    msgServer = MessageServer(sys.argv)
+    msgServer = MessageServer()
     msgServer.show()
 
     sys.exit(app.exec_())


### PR DESCRIPTION
# Generally
Convert all msgtools command line utilites to use argparse, and provide full command line help with the -h option.  Along with all this came a few more command line error checks, with abbreviated help if command line arguments are missing or appear incorrect.  With the exceptions noted below command line arguments, and app behavior, have remained identical to pre-argparse.

"Client" tools (inspector,  multilog, noisemaker, bandwidth tester, scope) support a set of common options for connecting sockets, serial, Bluetooth, and files.  Some tools have disabled this functionality.  Specifically: Goodlistener, and Lumberjack.   The latter is artificially limited to just file inputs until sockets and other methods can be retested.  Note that these options have always been there, the command line help just hasn't advertised them until now.

# Goodlistener
Pre-argparse, doesn't appear to run without further customization.  Kept the command line identical with argparse.  ResultsFilename appears unused, but the option is still there to keep the command line the same.

# Lumberjack
Hard coded to file input only until further testing can be done to confirm sockets etc.  Issue #76

# Multilog
Identical to pre-argparse.    Including a crash in the ProcessMessage method.  Issue #75

# Noisemaker
Identical to pre-argparse.  Fixed msgs argument so it works.  Original code crashed.

# Parser
Templates are now optional (defaulting to the language package).  -t and -ht can be used to specify them.  Plugins always require templates since we can't infer a directory easily.