### PR TITLE
Fix for issue #30.  Loop until all bytes have been sent.

### DIFF
--- a/msgtools/server/TcpServer.py
+++ b/msgtools/server/TcpServer.py
@@ -65,8 +65,13 @@ class TcpClientConnection(QObject):
         self.disconnected.emit(self)
 
     def sendMsg(self, msg):
-        self.tcpSocket.write(msg.rawBuffer().raw)
-
+        buf = msg.rawBuffer().raw
+        while len(buf) > 0:
+            bytesWritten = self.tcpSocket.write(buf)
+            if bytesWritten == -1:
+                raise Exception('Write error (-1)')
+            buf = buf[bytesWritten:]
+    
 class TcpServer(QObject):
     statusUpdate = QtCore.pyqtSignal(str)
     newConnection = QtCore.pyqtSignal(object)


### PR DESCRIPTION
Pretty standard loop pattern.  Go until all bytes are sent.  Throw an exception if no bytes are sent assuming a more critical error and avoiding a potentially infinite loop.