### PR TITLE
Issue #85 General Support for the --msg option

### DIFF
--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -79,10 +79,6 @@ class MsgInspector(msgtools.lib.gui.Gui):
         if len(msgRoute) > 0 and not(all ("0" == a for a in msgRoute)):
             msgKey += " ("+",".join(msgRoute)+")"
 
-        if self.allowedMessages:
-            if not msg.MsgName() in self.allowedMessages:
-                return
-
         if(not(msgKey in self.msgWidgets)):
             # create a new tree widget
             try:

--- a/msgtools/inspector/inspector.py
+++ b/msgtools/inspector/inspector.py
@@ -20,9 +20,9 @@ DESCRIPTION='''MsgInspector allows you to connect to a MsgServer and inspect mes
 class MsgInspector(msgtools.lib.gui.Gui):
     def __init__(self, parent=None):
         parser = argparse.ArgumentParser(description=DESCRIPTION)
-        parser.add_argument('--msgfields', nargs='+', help='''One or more msgName/fieldName specifiers which we'll use to 
-            set which field on a message can be used for sorting. Example --keyfields Printf/LineNumber.  If --msgs is specified
-            and a msgfied is requested that isn\'t in the whitelist the message will be added to the whitelist for you.''')
+        parser.add_argument('--sortfields', nargs='+', help='''One or more msgName/fieldName specifiers used to indicate
+            which field on a message should be used for sorting. Example --sortfields Printf/LineNumber.  If --msgs is specified,
+            and a message name is requested that isn\'t in the whitelist, the message will be added to the whitelist for you.''')
         parser = msgtools.lib.gui.Gui.addBaseArguments(parser)
         args=parser.parse_args()
 
@@ -31,12 +31,12 @@ class MsgInspector(msgtools.lib.gui.Gui):
         self.keyFields = {}
 
         # Process our msg/keyfields
-        if args.msgfields is not None:
-            for msgfield in args.msgfields:
+        if args.sortfields is not None:
+            for sortfield in args.sortfields:
                 try:
-                    msgName,fieldName = msgfield.split('/')
+                    msgName,fieldName = sortfield.split('/')
                 except Exception:
-                    print('--msgfields {0} is invalid.  Specify a message name and field name separated by a forward slash.'.format(msgfield))
+                    print('--sortfields {0} is invalid.  Specify a message name and field name separated by a forward slash.'.format(sortfield))
                     sys.exit(1)
 
                 if msgName not in Messaging.MsgIDFromName:

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -74,7 +74,6 @@ class App(QtWidgets.QMainWindow):
         self.rxBuf = bytearray()
         
         self.allowedMessages = []
-        self.keyFields = {}
         
         # flag that indicates if we're connected
         self.connected = False
@@ -231,8 +230,6 @@ class App(QtWidgets.QMainWindow):
         msg = Messaging.MsgFactory(hdr)
         if self._messageAllowed(msg):
             self.RxMsg.emit(msg)
-        else:
-            print('Not allowed')
 
     def _messageAllowed(self, msg):
         '''Check msg against the list of allowed messages.

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -36,7 +36,7 @@ class App(QtWidgets.QMainWindow):
                     This parameter is overridden by the --ip and --port options.''')
         parser.add_argument('--ip', help='The IP address for a socket connection.   Overrides connectionName.')
         parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
-        parser.add_argument('--msg', nargs='+', help='''A space delimited list of white list messages to process.
+        parser.add_argument('--msg', nargs='+', default=set(), help='''A space delimited list of white list messages to process.
                     All messages outside of this list will be ignored.  For example: --msg TestCase1 Network.Note 
                     Taxonomy/Candidae.AFox''')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
@@ -73,7 +73,7 @@ class App(QtWidgets.QMainWindow):
         # rx buffer, to receive a message with multiple signals
         self.rxBuf = bytearray()
         
-        self.allowedMessages = []
+        self.allowedMessages = set(args.msg)
         
         # flag that indicates if we're connected
         self.connected = False
@@ -91,8 +91,6 @@ class App(QtWidgets.QMainWindow):
             self.connectionName = args.connectionName
         if args.ip is not None:
             ip = args.ip
-        if args.msg is not None:
-            self.allowedMessages = args.msg
         if args.msgdir:
             msgLoadDir = args.msgdir
         
@@ -237,7 +235,7 @@ class App(QtWidgets.QMainWindow):
         return True if all messages are allowed, or the message is
         in the message white list.'''
         retVal = True
-        if self.allowedMessages:
+        if len(self.allowedMessages) > 0:
             if not msg.MsgName() in self.allowedMessages:
                 retVal = False
 

--- a/msgtools/lib/app.py
+++ b/msgtools/lib/app.py
@@ -36,7 +36,9 @@ class App(QtWidgets.QMainWindow):
                     This parameter is overridden by the --ip and --port options.''')
         parser.add_argument('--ip', help='The IP address for a socket connection.   Overrides connectionName.')
         parser.add_argument('--port', type=int, help='The port for a socket connection. Overrides connectionName.')
-        parser.add_argument('--msg', help='Allowed messages followed by a slash ("/") followed key fields.')
+        parser.add_argument('--msg', nargs='+', help='''A space delimited list of white list messages to process.
+                    All messages outside of this list will be ignored.  For example: --msg TestCase1 Network.Note 
+                    Taxonomy/Candidae.AFox''')
         parser.add_argument('--msgdir', help=''''The directory to load Python message source from.''')
         parser.add_argument('--serial', action='store_true', help='Set if you want to use a SerialHeader instead of a NetworkHeader.')
 
@@ -90,14 +92,8 @@ class App(QtWidgets.QMainWindow):
             self.connectionName = args.connectionName
         if args.ip is not None:
             ip = args.ip
-        if args.port is not None:
-            port = args.port
         if args.msg is not None:
-            option = args.msg.split('/')
-            self.allowedMessages.append(option[0])
-            if len(option) > 1:
-                self.keyFields[option[0]] = option[1]
-            print("only allowing msg " + str(option))
+            self.allowedMessages = args.msg
         if args.msgdir:
             msgLoadDir = args.msgdir
         
@@ -110,6 +106,15 @@ class App(QtWidgets.QMainWindow):
 
         try:
             self.msgLib = Messaging(msgLoadDir, 0, headerName)
+
+            if args.msg is not None:
+                # Validate all message names are valid
+                for msg in args.msg:
+                    if msg not in Messaging.MsgIDFromName:
+                        print('{0} is not a valid message name!'.format(msg))
+                        sys.exit(1)
+                port = args.port
+
         except ImportError:
             print("\nERROR! Auto-generated python code not found!")
             print("cd to a directory downstream from a parent of obj/CodeGenerator/Python")
@@ -215,9 +220,31 @@ class App(QtWidgets.QMainWindow):
 
     # Qt signal/slot based reading of websocket
     def processBinaryMessage(self, bytes):
-        hdr = Messaging.hdr(bytes.data())
-        # if we got this far, we have a whole message! So, emit the signal
-        self.RxMsg.emit(Messaging.MsgFactory(hdr))
+        if isinstance(bytes, bytearray):
+            hdr = Messaging.hdr(bytes)
+        else:
+            # Assume this is a QByteArray from a websocket
+            hdr = Messaging.hdr(bytes.data())
+
+        # if we got this far, we have a whole message! Emit the signal
+        # if the message is whitelisted
+        msg = Messaging.MsgFactory(hdr)
+        if self._messageAllowed(msg):
+            self.RxMsg.emit(msg)
+        else:
+            print('Not allowed')
+
+    def _messageAllowed(self, msg):
+        '''Check msg against the list of allowed messages.
+
+        return True if all messages are allowed, or the message is
+        in the message white list.'''
+        retVal = True
+        if self.allowedMessages:
+            if not msg.MsgName() in self.allowedMessages:
+                retVal = False
+
+        return retVal
 
     # Qt signal/slot based reading of TCP socket
     def readRxBuffer(self):
@@ -248,12 +275,10 @@ class App(QtWidgets.QMainWindow):
             if(len(self.rxBuf) < Messaging.hdrSize + bodyLen):
                 print("don't have full body, quitting")
                 return
-            
-            # create a new header object with the appended body
-            hdr = Messaging.hdr(self.rxBuf)
 
-            # if we got this far, we have a whole message! So, emit the signal
-            self.RxMsg.emit(Messaging.MsgFactory(hdr))
+            # Process what we assume to be a full message...            
+            self.processBinaryMessage(self.rxBuf)
+
             # then clear the buffer, so we start over on the next message
             self.rxBuf = bytearray()
     
@@ -325,7 +350,11 @@ class App(QtWidgets.QMainWindow):
                 # create a new header object with the appended body
                 hdr = Messaging.hdr(self.rxBuf)
 
-                # got a complete message, call the callback to process it
-                self.ProcessMessage(Messaging.MsgFactory(hdr))
+                # got a complete message, call the callback to process it if
+                # the message is on our white list
+                msg = Messaging.MsgFactory(hdr)
+                if self._messageAllowed(msg):
+                    self.ProcessMessage(msg)
         except StopIteration:
             print("found end of file, exited")
+

--- a/msgtools/multilog/multilog.py
+++ b/msgtools/multilog/multilog.py
@@ -203,11 +203,6 @@ class Multilog(msgtools.lib.gui.Gui):
             handlersList = self.msgHandlers[msg.ID]
             for handler in handlersList:
                 handler.addData(msg)
-        # if user specified allowed messages...
-        if self.allowedMessages:
-            # only log this message if it's in that list
-            if not msg.MsgName() in self.allowedMessages:
-                return
         
         if self.file is not None:
             #write to a single binary log file


### PR DESCRIPTION
As I got into it, I realized that inspector relies on an optional field component which is unique to inspector.  I decided to make the base class implementation (--msg) allow you to specify a whitelist of messages that will be accepted in general.   Inspector adds a --sortfields argument that allows you to specify the sort fieldname to support it's specific UI.  Summary of features:

* --msg is a list of message names
* Each message name is verified to exist in the Message directory
* --sortfields similarly verifies message and field name existence with the message dictionary
* if --msg is specified --sortfields will automatically add messages to the whitelist if they aren't already present.
