### PR TITLE
jcenter seems to have removed some JARs, pull straight from google

### DIFF
--- a/AndroidServer/build.gradle
+++ b/AndroidServer/build.gradle
@@ -2,6 +2,7 @@
 
 buildscript {
     repositories {
+        maven { url "https://maven.google.com" }
         jcenter()
     }
     dependencies {
@@ -14,6 +15,7 @@ buildscript {
 
 allprojects {
     repositories {
+        maven { url "https://maven.google.com" }
         jcenter()
     }
 }


### PR DESCRIPTION
There's some sort of weirdness going on with jcenter, where some jars are occasionally/always missing.
This takes care of that, so the Travis CI builds can finish consistently.