### PR TITLE
Move PyQT back to extras

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,11 +39,10 @@ setup(name='msgtools',
         'pyyaml',
         'websockets',
         'janus',
-        'jinja2',
-        'pyqt5' # This is so instrinsic to most tools; just install it.
+        'jinja2'
     ],
     extras_require={
-        'gui':  ["pyqtgraph"],
+        'gui':  ["pyqtgraph", "pyqt5"],
         'serverserial': ["pyqtserial"],
     },
     package_data={


### PR DESCRIPTION
PyQT is somewhat large and comes with dependencies that may be difficult to satisfy on all platforms.  For users who just want to generate code there really isn't a good reason to burden them with the hassle.  pip install msgtoolsgui is a better route.