### PR TITLE
Structs

### DIFF
--- a/msgtools/lib/messaging.py
+++ b/msgtools/lib/messaging.py
@@ -150,11 +150,9 @@ class Messaging:
     # add message to the global hash table of IDs by name
     def AddAlias(name, id, classDef):
         if(name in Messaging.MsgIDFromName):
-            print("WARNING! Trying to define message ", name, " for ID ", id, ", but ", Messaging.MsgIDFromName[name], " already uses that ID")
-        Messaging.MsgIDFromName[name] = id
+            print("WARNING! Trying to define message %s for ID %s(%d), but %s(%d) already uses that name" % (name, id, int(id, 0), Messaging.MsgIDFromName[name], int(Messaging.MsgIDFromName[name], 0)))
 
-        if(name in Messaging.MsgClassFromName):
-            print("WARNING! Trying to define message ", name, " but already in use by ID ", Messaging.MsgIDFromName[name])
+        Messaging.MsgIDFromName[name] = id
         Messaging.MsgClassFromName[name] = classDef
 
         # split up the name between periods, and add it to the Messaging object so it

--- a/msgtools/lib/messaging.py
+++ b/msgtools/lib/messaging.py
@@ -360,11 +360,11 @@ class Messaging:
         if msgName in Messaging.MsgClassFromName:
             msgClass = Messaging.MsgClassFromName[msgName]
             msg = msgClass()
+            terminateMsg = 0
+            terminationLen = 0
             if msg.fields:
                 try:
                     paramNumber = 0
-                    terminateMsg = 0
-                    terminationLen = 0
                     for fieldInfo in msgClass.fields:
                         val = params[paramNumber].strip()
                         #print("val is [" + val + "]") 

--- a/msgtools/parser/MsgUtils.py
+++ b/msgtools/parser/MsgUtils.py
@@ -285,17 +285,14 @@ def msgID(msg, enums, undefinedMsgId):
     #print("message " + msg["Name"] + " has ID " + hex(ret))
     return str(ret)
 
-namespaceForFilename = False
-def SetNamespaceForFilename(val):
-    global namespaceForFilename
-    namespaceForFilename = val
-
 def msgDescriptor(msg, inputFilename):
     subdir = msg["commonSubdir"]
     name = msgName(msg)
     basename = os.path.basename(inputFilename).split('.')[0]
-    if namespaceForFilename and name != basename:
+    # add the filename as a namespace, unless it's already there
+    if not basename == name and not basename+'_' in name:
         name = basename + '.' + name
+        print("adding basename " + basename + " to " + name)
     if name.startswith(subdir+"_"):
         return name.replace("_", ".")
     if subdir and not name.startswith(subdir):

--- a/msgtools/parser/MsgUtils.py
+++ b/msgtools/parser/MsgUtils.py
@@ -401,6 +401,9 @@ def PatchStructs(inputData):
                             for subfield in s['Fields']:
                                 subfieldcopy = copy.deepcopy(subfield)
                                 subfieldcopy['Name'] = field['Name'] + "_" + subfield['Name']
+                                if "Bitfields" in subfieldcopy:
+                                    for bits in subfieldcopy["Bitfields"]:
+                                        bits['Name'] = field['Name'] + "_" + bits['Name']
                                 outfields.append(subfieldcopy)
                         else:
                             outfields.append(field)

--- a/msgtools/parser/check.py
+++ b/msgtools/parser/check.py
@@ -74,32 +74,32 @@ def ProcessMsg(filename, msg, subdirComponent, enums):
         for field in msg["Fields"]:
             bitOffset = 0
             if not re.match("^[\w\d_]+$", field["Name"]):
-                raise MessageException('bad field name [' + field["Name"]+"]")
+                raise MessageException('bad field name [' + field["Name"]+"] in message "+msgName(msg))
             if field["Name"] in fieldNames:
-                raise MessageException('Duplicate field name [' + field["Name"]+"]")
+                raise MessageException('Duplicate field name [' + field["Name"]+"] in message "+msgName(msg))
             fieldNames[field["Name"]] = field["Name"]
             if not fieldTypeValid(field):
-                raise MessageException('field ' + field["Name"] + ' has invalid type ' + field['Type'])
+                raise MessageException('field ' + field["Name"] + ' has invalid type ' + field['Type']+ " in message "+msgName(msg))
             if "Enum" in field:
                 if not field["Enum"] in enumNames:
-                    raise MessageException('bad enum [' + field["Enum"]+"]")
+                    raise MessageException('bad enum [' + field["Enum"]+"] in message "+msgName(msg))
                 if " " in field["Enum"]:
-                    raise MessageException('bad enum [' + field["Enum"]+"]")
+                    raise MessageException('bad enum [' + field["Enum"]+"] in message "+msgName(msg))
                 pass
             if "Bitfields" in field:
                 for bits in field["Bitfields"]:
                     numBits = bits["NumBits"]
                     bitOffset += numBits
                     if not re.match("^[\w\d_]+$", bits["Name"]):
-                        raise MessageException('bad bitfield name [' + bits["Name"]+"]")
+                        raise MessageException('bad bitfield name [' + bits["Name"]+"] in message "+msgName(msg))
                     if bits["Name"] in fieldNames:
-                        raise MessageException('Duplicate bitfield name [' + bits["Name"]+"] in field ["+field["Name"]+"]")
+                        raise MessageException('Duplicate bitfield name [' + bits["Name"]+"] in field ["+field["Name"]+"] in message "+msgName(msg))
                     fieldNames[bits["Name"]] = bits["Name"]
                 if bitOffset > 8*fieldSize(field):
-                    raise MessageException('too many bits')
+                    raise MessageException('too many bits in message '+msgName(msg))
                 if "Enum" in bits:
                     if not bits["Enum"] in enumNames:
-                        raise MessageException('bad enum')
+                        raise MessageException('bad enum in message '+msgName(msg))
                     pass
             # disable enforcement of native alignment
             #if offset % fieldSize(field) != 0:

--- a/msgtools/parser/check.py
+++ b/msgtools/parser/check.py
@@ -111,6 +111,8 @@ def ProcessMsg(filename, msg, subdirComponent, enums):
 def ProcessFile(filename, outFile, inputData, subdirComponent):
     enums = Enums(inputData)
     ids = MsgIDs(inputData)
+    
+    PatchStructs(inputData)
 
     if "Messages" in inputData:
         for msg in Messages(inputData):

--- a/msgtools/parser/check.py
+++ b/msgtools/parser/check.py
@@ -38,12 +38,12 @@ def ProcessDir(outFile, msgDir, subdirComponent):
                 sys.stderr.write('Error in ' + inputFilename)
                 sys.stderr.write('\n'+str(e)+'\n')
                 outFile.close()
-                os.remove(outputFilename)
+                os.remove(outFile.name)
                 sys.exit(1)
             except:
                 sys.stderr.write("\nError in " + inputFilename + "!\n\n")
                 outFile.close()
-                os.remove(outputFilename)
+                os.remove(outFile.name)
                 raise
 
 def fieldTypeValid(field):

--- a/msgtools/parser/parser.py
+++ b/msgtools/parser/parser.py
@@ -311,8 +311,6 @@ def main():
     parser.add_argument('-ht', '--headertemplate', dest='headertemplate', 
         help='''Header template applied to messages in the "headers" folder.  If unspecified defaults to the 
                 template provided by MsgTools.''')
-    parser.add_argument('--namespaceforfilename', action='store_true',
-        help='If the input filename should be used to make a message namespace')
     args = parser.parse_args()
   
     global inputFilename, outputFilename, languageFilename, templateFilename, headerTemplateFilename
@@ -321,7 +319,6 @@ def main():
     languageFilename = args.language
     templateFilename = args.template
     headerTemplateFilename = args.headertemplate
-    SetNamespaceForFilename(args.namespaceforfilename)
 
     # import the language file
     global language

--- a/msgtools/parser/parser.py
+++ b/msgtools/parser/parser.py
@@ -172,6 +172,8 @@ def ProcessFile(inputFilename, outDir, languageFilename, templateFilename):
     enums = Enums(inputData)
     ids = MsgIDs(inputData)
     
+    PatchStructs(inputData)
+    
     firstTime = True
     if "Messages" in inputData:
         for msg in Messages(inputData):

--- a/msgtools/parser/parser.py
+++ b/msgtools/parser/parser.py
@@ -210,7 +210,7 @@ def ProcessFile(inputFilename, outDir, languageFilename, templateFilename):
                 replacements["<TEMPLATEFILENAME>"] = templateFilename
                 replacements["<LANGUAGEFILENAME>"] = languageFilename
                 replacements["<MESSAGE_PACKAGE>"] = msg["commonSubdir"].replace( '/', '.').replace( '\\', '.')
-                replacements["<MSGDESCRIPTOR>"] = msgDescriptor(msg)
+                replacements["<MSGDESCRIPTOR>"] = msgDescriptor(msg, inputFilename)
                 replacements["<DATE>"] = currentDateTime
                 replacements["<MSGALIAS>"] = msgAlias(msg)
                 for line in template:
@@ -311,6 +311,8 @@ def main():
     parser.add_argument('-ht', '--headertemplate', dest='headertemplate', 
         help='''Header template applied to messages in the "headers" folder.  If unspecified defaults to the 
                 template provided by MsgTools.''')
+    parser.add_argument('--namespaceforfilename', action='store_true',
+        help='If the input filename should be used to make a message namespace')
     args = parser.parse_args()
   
     global inputFilename, outputFilename, languageFilename, templateFilename, headerTemplateFilename
@@ -319,6 +321,7 @@ def main():
     languageFilename = args.language
     templateFilename = args.template
     headerTemplateFilename = args.headertemplate
+    SetNamespaceForFilename(args.namespaceforfilename)
 
     # import the language file
     global language


### PR DESCRIPTION
Add support for referencing Structs like existing Enums. Structs will have a list of fields like Messages do, but will not have Message metadata like an ID. They aren't a message, they are a set of fields that can be inserted into other messages.

Add option to enable namespaceForFilename, defaulted to False (legacy behaviour).  If we can determine that the new behaviour doesn't break existing users, we could make namespaceForFilename the only mode of operation.