### PR TITLE
messaging.py:

### DIFF
--- a/msgtools/lib/messaging.py
+++ b/msgtools/lib/messaging.py
@@ -354,7 +354,7 @@ class Messaging:
         elif("float" in fieldInfo.type):
             value = float(value)
         
-        if not hasattr(fieldInfo, "count") or fieldInfo.count == 1:
+        if fieldInfo.count == 1:
             fieldInfo.set(msg, value)
         else:
             fieldInfo.set(msg, value, index)
@@ -362,7 +362,7 @@ class Messaging:
     @staticmethod
     def get(msg, fieldInfo, index=0):
         try:
-            if not hasattr(fieldInfo, "count") or fieldInfo.count == 1:
+            if fieldInfo.count == 1:
                 value = fieldInfo.get(msg)
             else:
                 value = fieldInfo.get(msg, index)
@@ -394,13 +394,11 @@ class Messaging:
     @staticmethod
     def findFieldInfo(fieldInfos, name):
         for fi in fieldInfos:
-            if len(fi.bitfieldInfo) == 0:
-                if name == fi.name:
-                    return fi
-            else:
-                for bfi in fi.bitfieldInfo:
-                    if name == bfi.name:
-                        return bfi
+            if name == fi.name:
+                return fi
+            for bfi in fi.bitfieldInfo:
+                if name == bfi.name:
+                    return bfi
         return None
 
     # This is composed of all the header fields that are not length, time, and any ID fields.
@@ -435,6 +433,7 @@ class BitFieldInfo(object):
         self.description=description
         self.get=get
         self.set=set
+        self.count=1
         self.enum=enum
         self.idbits=idbits
 

--- a/msgtools/lib/txtreewidget.py
+++ b/msgtools/lib/txtreewidget.py
@@ -14,6 +14,7 @@ class FieldItem(QTreeWidgetItem):
         QTreeWidgetItem.__init__(self, None, column_strings)
         
         self.fieldInfo = fieldInfo
+        self.fieldName = fieldInfo.name
         self.msg = msg
         
     def data(self, column, role):
@@ -141,6 +142,10 @@ class FieldArrayItem(QTreeWidgetItem):
         QTreeWidgetItem.__init__(self, None, column_strings)
         
         self.fieldInfo = fieldInfo
+        if index == None:
+            self.fieldName = fieldInfo.name
+        else:
+            self.fieldName = "%s[%d]" % (fieldInfo.name, index)
         self.msg = msg
         self.index = index
 


### PR DESCRIPTION
    Make BitFieldInfo have a count = 1, just like FieldInfo for non-arrays.
    Then anyone with either type of info can just look at 'count'.

txtreewidget.py:
    Make tree widgets remember 'fieldName', for use in drag-and-drop to create plots.

msgplot.py, multilog.py, scope.py:
    Handle plotting of array fields.
    Cycle through more line colors, not just 3.
    Revert use of argparse.