### PR TITLE
Support __init__.py creation for Python

### DIFF
--- a/msgtools/parser/parser.py
+++ b/msgtools/parser/parser.py
@@ -236,6 +236,11 @@ def ProcessDir(msgDir, outDir, languageFilename, templateFilename, headerTemplat
     # make the output directory
     try:
         os.makedirs(outDir)
+
+        # Give the language module a chance to do any language specific processing.
+        # For example, Python creates __init__.py for Python 2 module support.
+        if hasattr(language, 'onNewOutputDirectory'):
+            language.onNewOutputDirectory(msgDir, outDir)
     except:
         pass
     for filename in os.listdir(msgDir):

--- a/msgtools/parser/python/language.py
+++ b/msgtools/parser/python/language.py
@@ -313,3 +313,14 @@ def getMsgID(msg):
     
 def setMsgID(msg):
     return baseSetMsgID("self.", "", 0, 1, msg)
+
+#
+# MsgParser "event" handling functions
+#
+def onNewOutputDirectory(msgDir, outDir):
+    '''Invoked by MsgParser when it's creating a new output directory.
+    We need to create an empty __init__.py module in Python output
+    directories so Python 2 can properly resolve modules.'''
+    filename = os.path.join(outDir, '__init__.py')
+    print('Creating %s' % filename)
+    open(filename, 'at').close()


### PR DESCRIPTION
We don't  officially support Python2, but it turns out all we need to do is add __init__.py to subfolders to make Python2's importer happy.  Previously put this directly into msgparser, but I failed to recall that we'd be creating __init__.py files for all languages.

Created a Python specific solution by invoking an optional language module function when a new directory is created and letting Python handle __init__.py directly.  This opens a pattern of other msgparser events for similar language specific handling.  

Went this route instead of a makefile as not everyone is required to use MsgTools' make infrastructure, and support to add __init__.py is trivial.  Not adding any real maintenance or processing overhead. 

That said, if a makefile solution is preferred, I can dump this and add that instead.